### PR TITLE
Fixing flaky testConfigReloading by adding a proper waits instead of Thread.sleep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     testImplementation "org.openjdk.jmh:jmh-core:1.37"
     testImplementation "org.openjdk.jmh:jmh-generator-annprocess:1.37"
     testImplementation "org.assertj:assertj-core:3.25.3"
+    testImplementation 'org.awaitility:awaitility:4.2.1'
 
     jmh "org.apache.kafka:kafka_2.12:${kafkaVersion}"
 }


### PR DESCRIPTION
The config reloading is quite quick but not instantaneous, so on some systems just having a Thread.sleep with some timeout is not enough.