### PR TITLE
feat: add acl host matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ By default, the permission type is `ALLOW`.
                 "O=00000000-0000-a000-1000-(500000000005|a00000000001|b00000000001|d00000000001),ST=vm$"
             ),
             "principal_type": "Prune",
+            "host": "*",
             "resource": "^(.*)$",
         },
         {
             "operation": "^(Describe|DescribeConfigs|Read|Write)$",
             "principal": "^CN=(?<vmname>[a-z0-9-]+),OU=(?<nodeid>n[0-9]+),O=(?<projectid>[a-f0-9-]+),ST=vm$",
             "principal_type": "Prune",
+            "host": "*",
             "resource_pattern": "^Topic:${projectid}-(.*),
             "permission_type": "DENY"
         }

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
@@ -192,7 +192,9 @@ public class AivenAclAuthorizerV2 implements Authorizer {
             final String resourceToCheck =
                 LegacyResourceTypeNameFormatter.format(resourcePattern.resourceType())
                 + ":" + resourcePattern.name();
+            final String host = requestContext.clientAddress().getHostAddress();
             final boolean verdict = cacheReference.get().get(principal,
+                                                             host,
                                                              LegacyOperationNameFormatter.format(operation),
                                                              resourceToCheck);
             final var authResult = verdict ? AuthorizationResult.ALLOWED : AuthorizationResult.DENIED;

--- a/src/main/java/io/aiven/kafka/auth/VerdictCache.java
+++ b/src/main/java/io/aiven/kafka/auth/VerdictCache.java
@@ -41,18 +41,22 @@ public class VerdictCache {
         this.allowAclEntries = allowAclEntries;
     }
 
-    public boolean get(final KafkaPrincipal principal,
-                       final String operation,
-                       final String resource) {
+    public boolean get(
+        final KafkaPrincipal principal,
+        final String host,
+        final String operation,
+        final String resource
+    ) {
         final String principalType = principal.getPrincipalType();
         final String cacheKey = resource
             + "|" + operation
+            + "|" + host
             + "|" + principal.getName()
             + "|" + principalType;
 
         return cache.computeIfAbsent(cacheKey, key -> {
             final Predicate<AivenAcl> matcher = acl ->
-                acl.match(principalType, principal.getName(), operation, resource);
+                acl.match(principalType, principal.getName(), host, operation, resource);
             if (denyAclEntries.stream().anyMatch(matcher)) {
                 return false;
             } else {

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
@@ -42,7 +42,7 @@ public class AclAivenToNativeConverter {
             );
             for (final var principal : principals) {
                 final var accessControlEntry = new AccessControlEntry(
-                    principal, "*", operation, aivenAcl.getPermissionType().nativeType);
+                    principal, aivenAcl.getHostMatcher(), operation, aivenAcl.getPermissionType().nativeType);
                 for (final var resourcePattern : ResourcePatternParser.parse(aivenAcl.resourceRe.pattern())) {
                     result.add(new AclBinding(resourcePattern, accessControlEntry));
                 }

--- a/src/test/java/io/aiven/kafka/auth/json/AivenAclTest.java
+++ b/src/test/java/io/aiven/kafka/auth/json/AivenAclTest.java
@@ -28,46 +28,49 @@ public class AivenAclTest {
         AivenAcl entry = new AivenAcl(
             "User", // principal type
             "^CN=p_(.*)_s$", // principal
+            "*", // host
             "^(Describe|Read)$", // operation
             "^Topic:p_(.*)_s", // resource,
             null, // resource pattern
             null
         );
 
-        assertTrue(entry.match("User", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=fail", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=p_pass_s", "Write", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=p_pass_s", "Read", "Topic:fail"));
-        assertFalse(entry.match("NonUser", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
+        assertTrue(entry.match("User",  "CN=p_pass_s", "*", "Read", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=fail", "*", "Read", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=p_pass_s", "*", "Write", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=p_pass_s", "*", "Read", "Topic:fail"));
+        assertFalse(entry.match("NonUser", "CN=p_pass_s", "*", "Read", "Topic:p_pass_s"));
 
         // Test with principal undefined
         entry = new AivenAcl(
             null, // principal type
             "^CN=p_(.*)_s$", // principal
+            "*", // host
             "^(Describe|Read)$", // operation
             "^Topic:p_(.*)_s", // resource
             null, // resource pattern
             null
         );
 
-        assertTrue(entry.match("User", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
-        assertTrue(entry.match("NonUser", "CN=p_pass_s", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=fail", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=p_pass_s", "Read", "Topic:fail"));
+        assertTrue(entry.match("User", "CN=p_pass_s", "*", "Read", "Topic:p_pass_s"));
+        assertTrue(entry.match("NonUser", "CN=p_pass_s", "*", "Read", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=fail", "*", "Read", "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=p_pass_s", "*", "Read", "Topic:fail"));
 
         // Test resources defined by pattern
         entry = new AivenAcl(
             "User", // principal type
             "^CN=p_(?<username>[a-z0-9]+)_s$", // principal
+            "*", // host
             "^(Describe|Read)$", // operation
             null, // resource
             "^Topic:p_${username}_s\\$", // resource pattern
             null
         );
 
-        assertTrue(entry.match("User", "CN=p_user1_s", "Read", "Topic:p_user1_s"));
-        assertTrue(entry.match("User", "CN=p_user2_s", "Read", "Topic:p_user2_s"));
-        assertFalse(entry.match("User", "CN=p_user1_s", "Read", "Topic:p_user2_s"));
-        assertFalse(entry.match("User", "CN=p_user2_s", "Read", "Topic:p_user1_s"));
+        assertTrue(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:p_user1_s"));
+        assertTrue(entry.match("User", "CN=p_user2_s", "*", "Read", "Topic:p_user2_s"));
+        assertFalse(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:p_user2_s"));
+        assertFalse(entry.match("User", "CN=p_user2_s", "*", "Read", "Topic:p_user1_s"));
     }
 }

--- a/src/test/java/io/aiven/kafka/auth/json/reader/AclJsonReaderTest.java
+++ b/src/test/java/io/aiven/kafka/auth/json/reader/AclJsonReaderTest.java
@@ -36,24 +36,27 @@ public class AclJsonReaderTest {
         final var jsonReader = new AclJsonReader(path);
         final var acls = jsonReader.read();
         assertThat(acls).containsExactly(
-            new AivenAcl("User", "^pass-3$", "^Read$", "^Topic:denied$", null, AclPermissionType.DENY),
-            new AivenAcl("User", "^pass-0$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-1$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-2$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-3$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-4$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-5$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-6$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-7$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-8$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-9$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-10$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-11$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl("User", "^pass-12$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
-            new AivenAcl(null, "^pass-notype$", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-3$", "*", "^Read$", "^Topic:denied$", null, AclPermissionType.DENY),
+            new AivenAcl("User", "^pass-0$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-1$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-2$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-3$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-4$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-5$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-6$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-7$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-8$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-9$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-10$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-11$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-12$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl(null, "^pass-notype$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
             new AivenAcl(
-                "User", "^pass-resource-pattern$", "^Read$", null, "^Topic:${projectid}-(.*)", AclPermissionType.ALLOW
-            )
+                "User", "^pass-resource-pattern$", "*", "^Read$",
+                null, "^Topic:${projectid}-(.*)", AclPermissionType.ALLOW
+            ),
+            new AivenAcl("User", "^pass-13$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW),
+            new AivenAcl("User", "^pass-14$", "example.com", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW)
         );
     }
 
@@ -65,6 +68,7 @@ public class AclJsonReaderTest {
         final var allowAcl = new AivenAcl(
             "User",
             "^allow$",
+            "*",
             "^Read$",
             "^(.*)$",
             null,
@@ -73,6 +77,7 @@ public class AclJsonReaderTest {
         final var denyAcl = new AivenAcl(
             "User",
             "^deny$",
+            "*",
             "^Read$",
             "^(.*)$",
             null,

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
@@ -40,6 +40,7 @@ public class AclAivenToNativeConverterTest {
             new AivenAcl(
                 "User",
                 "^(test\\-user)$",
+                "*",
                 "^(Alter|AlterConfigs|Delete|Read|Write)$",
                 "^Topic:(xxx)$",
                 null,
@@ -72,6 +73,7 @@ public class AclAivenToNativeConverterTest {
             new AivenAcl(
                 "User",
                 "^(test\\-user)$",
+                "*",
                 "^Read$",
                 "^Topic:(xxx)$",
                 null,
@@ -92,6 +94,7 @@ public class AclAivenToNativeConverterTest {
             new AivenAcl(
                 "User",
                 "^(test\\-user)$",
+                "*",
                 "^Read$",
                 "^Topic:(topic\\.(.*))$",
                 null,
@@ -112,6 +115,7 @@ public class AclAivenToNativeConverterTest {
             new AivenAcl(
                 "User",
                 "^(test\\-user)$",
+                "*",
                 "^Read$",
                 "^Topic:(topic\\.(.*))$",
                 null,
@@ -132,6 +136,7 @@ public class AclAivenToNativeConverterTest {
             new AivenAcl(
                 "User",
                 "^(test\\-user)$",
+                "*",
                 "^(Delete|Read|Write)$",
                 "^Topic:(topic\\.(.*)|prefix\\-(.*))$",
                 null,
@@ -172,6 +177,7 @@ public class AclAivenToNativeConverterTest {
             new AivenAcl(
                 "User",
                 "^(admin)$",
+                "*",
                 "^(.*)$",
                 "^(.*)$",
                 null,
@@ -205,6 +211,7 @@ public class AclAivenToNativeConverterTest {
             new AivenAcl(
                 "User",
                 "^(.*)$",
+                "*",
                 "^Read$",
                 "^Topic:(xxx)$",
                 null,
@@ -226,6 +233,7 @@ public class AclAivenToNativeConverterTest {
             new AivenAcl(
                 "Group",
                 "^example$",
+                "*",
                 "^Read$",
                 "^Topic:(xxx)$",
                 null,
@@ -234,5 +242,27 @@ public class AclAivenToNativeConverterTest {
         );
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    public final void testConvertHostMatcher() {
+        final var result = AclAivenToNativeConverter.convert(
+            new AivenAcl(
+                "User",
+                "^(test\\-user)$",
+                "12.34.56.78",
+                "^Read$",
+                "^Topic:(xxx)$",
+                null,
+                null
+            )
+        );
+
+        assertThat(result).containsExactly(
+            new AclBinding(
+                new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL),
+                new AccessControlEntry("User:test\\-user", "12.34.56.78", AclOperation.READ, AclPermissionType.ALLOW)
+            )
+        );
     }
 }

--- a/src/test/resources/acls_full.json
+++ b/src/test/resources/acls_full.json
@@ -94,5 +94,19 @@
     "principal": "^pass-resource-pattern$",
     "operation": "^Read$",
     "resource_pattern": "^Topic:${projectid}-(.*)"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-13$",
+    "host": "*",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^pass-14$",
+    "host": "example.com",
+    "operation": "^Read$",
+    "resource": "^Topic:(.*)$"
   }
 ]

--- a/src/test/resources/acls_host_match.json
+++ b/src/test/resources/acls_host_match.json
@@ -1,0 +1,24 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^(.*)$",
+    "host": "*",
+    "operation": "^(.*)$",
+    "resource": "^Topic:topic-1$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^(.*)$",
+    "host": "192.168.123.45",
+    "operation": "^(.*)$",
+    "resource": "^Topic:topic-2$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^(.*)$",
+    "host": "192.168.123.47",
+    "operation": "^(.*)$",
+    "resource": "^Topic:topic-1$",
+    "permission_type": "DENY"
+  }
+]


### PR DESCRIPTION
Improve the Aiven ACL by adding the capability to match by host. The feature  support literals matching or `*` for wildcard.