### PR TITLE
feat: add acl resource literal and prefixed matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ Class implementing a single ACL entry verification. Principal, operation and
 resource are expressed as regular expressions.
 
 Alternatively to straight regular expression for resource, AivenAclEntry can
-be given a resource pattern with back references to principal regex. This is
-used internally in Aiven to map project id from certificate subject into
-project specific management topics. We can thus avoid encoding separate rules
-for each project.
+be given a resource pattern with back references to principal regex, a literal
+match or a prefixed match. The first is used internally in Aiven to map project
+id from certificate subject into project specific management topics. We can thus
+avoid encoding separate rules for each project. Literal and prefixed matchers
+work as defined in the Apache Kafka documentation. Only one resource matcher can be
+specified per acl.
 
 Permission type allows to define the verification result in case of an ACL match.
 By default, the permission type is `ALLOW`.

--- a/src/main/java/io/aiven/kafka/auth/utils/ResourceLiteralWildcardMatcher.java
+++ b/src/main/java/io/aiven/kafka/auth/utils/ResourceLiteralWildcardMatcher.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.utils;
+
+public class ResourceLiteralWildcardMatcher {
+    // Here "pattern" is something like "Topic:topic-1" or "Topic:*", where the second form is the
+    // wildcard matching. The wildcard match is a bit more difficult than comparing for just "*", because
+    // the prefix must be compared with the one of "resource".
+    public static boolean match(final String pattern, final String resource) {
+        if (pattern == null || resource == null) {
+            return false;
+        }
+        final int matchLength = Math.min(pattern.length(), resource.length());
+        for (int i = 0; i < matchLength; i++) {
+            if (pattern.charAt(i) != resource.charAt(i)) {
+                return false;
+            }
+            if (pattern.charAt(i) == ':') {
+                return pattern.length() > i + 1 && pattern.charAt(i + 1) == '*';
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerV2Test.java
+++ b/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerV2Test.java
@@ -440,6 +440,30 @@ public class AivenAclAuthorizerV2Test {
         );
     }
 
+    @Test
+    public void testResourceLiteralMatcher() throws IOException {
+        Files.copy(this.getClass().getResourceAsStream("/acls_resource_literal_match.json"), configFilePath);
+        startAuthorizer();
+        checkSingleAction(requestCtx("User", "user1"), action(READ_OPERATION, topic("topic-1")), true);
+        checkSingleAction(requestCtx("User", "user1"), action(READ_OPERATION, topic("topic-2")), false);
+        checkSingleAction(requestCtx("User", "user2"), action(READ_OPERATION, topic("topic-2")), false);
+        checkSingleAction(requestCtx("User", "user3"), action(READ_OPERATION, topic("topic-3")), true);
+    }
+
+    @Test
+    public void testResourcePrefixMatcher() throws IOException {
+        Files.copy(this.getClass().getResourceAsStream("/acls_resource_prefix_match.json"), configFilePath);
+        startAuthorizer();
+        checkSingleAction(requestCtx("User", "user1"), action(READ_OPERATION, topic("groupA.topic")), true);
+        checkSingleAction(requestCtx("User", "user1"), action(READ_OPERATION, topic("groupC.topic")), false);
+        checkSingleAction(requestCtx("User", "user2"), action(READ_OPERATION, topic("groupB.topic")), false);
+    }
+
+
+    public ResourcePattern topic(final String name) {
+        return new ResourcePattern(ResourceType.TOPIC, name, PatternType.LITERAL);
+    }
+
     private void startAuthorizer() {
         final AuthorizerServerInfo serverInfo = mock(AuthorizerServerInfo.class);
         when(serverInfo.endpoints()).thenReturn(List.of());

--- a/src/test/java/io/aiven/kafka/auth/json/reader/AclJsonReaderTest.java
+++ b/src/test/java/io/aiven/kafka/auth/json/reader/AclJsonReaderTest.java
@@ -36,28 +36,42 @@ public class AclJsonReaderTest {
         final var jsonReader = new AclJsonReader(path);
         final var acls = jsonReader.read();
         assertThat(acls).containsExactly(
-            new AivenAcl("User", "^pass-3$", "*", "^Read$", "^Topic:denied$", null, AclPermissionType.DENY, false),
-            new AivenAcl("User", "^pass-0$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-1$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-2$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-3$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-4$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-5$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-6$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-7$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-8$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-9$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-10$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-11$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-12$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl(null, "^pass-notype$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl(
-                "User", "^pass-resource-pattern$", "*", "^Read$",
-                null, "^Topic:${projectid}-(.*)", AclPermissionType.ALLOW, false
-            ),
-            new AivenAcl("User", "^pass-13$", "*", "^Read$", "^Topic:(.*)$", null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-14$", "example.com", "^Read$", "^Topic:(.*)$",
-                null, AclPermissionType.ALLOW, true)
+            new AivenAcl("User", "^pass-3$", "*", "^Read$",
+                "^Topic:denied$", null, null, null, AclPermissionType.DENY, false),
+            new AivenAcl("User", "^pass-0$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-1$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-2$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-3$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-4$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-5$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-6$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-7$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-8$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-9$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-10$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-11$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-12$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl(null, "^pass-notype$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-resource-pattern$", "*", "^Read$",
+                null, "^Topic:${projectid}-(.*)", null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-13$", "*", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
+            new AivenAcl("User", "^pass-14$", "example.com", "^Read$",
+                "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, true)
         );
     }
 
@@ -73,7 +87,10 @@ public class AclJsonReaderTest {
             "^Read$",
             "^(.*)$",
             null,
-            AclPermissionType.ALLOW, false
+            null,
+            null,
+            AclPermissionType.ALLOW,
+            false
         );
         final var denyAcl = new AivenAcl(
             "User",
@@ -82,7 +99,10 @@ public class AclJsonReaderTest {
             "^Read$",
             "^(.*)$",
             null,
-            AclPermissionType.DENY, false
+            null,
+            null,
+            AclPermissionType.DENY,
+            false
         );
         assertThat(acls).containsExactly(allowAcl, allowAcl, allowAcl, denyAcl, denyAcl);
     }

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
@@ -44,7 +44,10 @@ public class AclAivenToNativeConverterTest {
                 "^(Alter|AlterConfigs|Delete|Read|Write)$",
                 "^Topic:(xxx)$",
                 null,
-                io.aiven.kafka.auth.json.AclPermissionType.ALLOW, false
+                null,
+                null,
+                io.aiven.kafka.auth.json.AclPermissionType.ALLOW,
+                false
             )
         );
         final ResourcePattern resourcePattern = new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL);
@@ -77,7 +80,10 @@ public class AclAivenToNativeConverterTest {
                 "^Read$",
                 "^Topic:(xxx)$",
                 null,
-                null, false
+                null,
+                null,
+                null,
+                false
             )
         );
         final ResourcePattern resourcePattern = new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL);
@@ -98,7 +104,10 @@ public class AclAivenToNativeConverterTest {
                 "^Read$",
                 "^Topic:(topic\\.(.*))$",
                 null,
-                null, false
+                null,
+                null,
+                null,
+                false
             )
         );
         assertThat(result).containsExactly(
@@ -119,7 +128,10 @@ public class AclAivenToNativeConverterTest {
                 "^Read$",
                 "^Topic:(topic\\.(.*))$",
                 null,
-                io.aiven.kafka.auth.json.AclPermissionType.DENY, false
+                null,
+                null,
+                io.aiven.kafka.auth.json.AclPermissionType.DENY,
+                false
             )
         );
         assertThat(result).containsExactly(
@@ -140,7 +152,10 @@ public class AclAivenToNativeConverterTest {
                 "^(Delete|Read|Write)$",
                 "^Topic:(topic\\.(.*)|prefix\\-(.*))$",
                 null,
-                null, false
+                null,
+                null,
+                null,
+                false
             )
         );
         assertThat(result).containsExactly(
@@ -181,7 +196,10 @@ public class AclAivenToNativeConverterTest {
                 "^(.*)$",
                 "^(.*)$",
                 null,
-                null, false
+                null,
+                null,
+                null,
+                false
             )
         );
 
@@ -207,7 +225,10 @@ public class AclAivenToNativeConverterTest {
                 "^Read$",
                 "^Topic:(xxx)$",
                 null,
-                null, false
+                null,
+                null,
+                null,
+                false
             )
         );
 
@@ -229,7 +250,10 @@ public class AclAivenToNativeConverterTest {
                 "^Read$",
                 "^Topic:(xxx)$",
                 null,
-                null, false
+                null,
+                null,
+                null,
+                false
             )
         );
 
@@ -246,13 +270,86 @@ public class AclAivenToNativeConverterTest {
                 "^Read$",
                 "^Topic:(xxx)$",
                 null,
-                null, false
+                null,
+                null,
+                null,
+                false
             )
         );
 
         assertThat(result).containsExactly(
             new AclBinding(
                 new ResourcePattern(ResourceType.TOPIC, "xxx", PatternType.LITERAL),
+                new AccessControlEntry("User:test\\-user", "12.34.56.78", AclOperation.READ, AclPermissionType.ALLOW)
+            )
+        );
+    }
+
+    @Test
+    public final void testConvertResourceRePattern() {
+        final var result = AclAivenToNativeConverter.convert(
+            new AivenAcl(
+                "Prune",
+                "^CN=(?<vmname>[a-z0-9-]+),OU=(?<nodeid>n[0-9]+),O=(?<projectid>[a-f0-9-]+),ST=vm$",
+                "12.34.56.78",
+                "^Read$",
+                null,
+                "^Topic:${projectid}-(.*)",
+                null,
+                null,
+                null,
+                false
+            )
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public final void testConvertResourceLiteral() {
+        final var result = AclAivenToNativeConverter.convert(
+            new AivenAcl(
+                "User",
+                "^(test\\-user)$",
+                "12.34.56.78",
+                "^Read$",
+                null,
+                null,
+                "Topic:some-topic-abcde",
+                null,
+                null,
+                false
+            )
+        );
+
+        assertThat(result).containsExactly(
+            new AclBinding(
+                new ResourcePattern(ResourceType.TOPIC, "some-topic-abcde", PatternType.LITERAL),
+                new AccessControlEntry("User:test\\-user", "12.34.56.78", AclOperation.READ, AclPermissionType.ALLOW)
+            )
+        );
+    }
+
+    @Test
+    public final void testConvertResourcePrefix() {
+        final var result = AclAivenToNativeConverter.convert(
+            new AivenAcl(
+                "User",
+                "^(test\\-user)$",
+                "12.34.56.78",
+                "^Read$",
+                null,
+                null,
+                null,
+                "Topic:prefixA.",
+                null,
+                false
+            )
+        );
+
+        assertThat(result).containsExactly(
+            new AclBinding(
+                new ResourcePattern(ResourceType.TOPIC, "prefixA.", PatternType.PREFIXED),
                 new AccessControlEntry("User:test\\-user", "12.34.56.78", AclOperation.READ, AclPermissionType.ALLOW)
             )
         );

--- a/src/test/java/io/aiven/kafka/auth/utils/ResourceLiteralWildcardMatcherTest.java
+++ b/src/test/java/io/aiven/kafka/auth/utils/ResourceLiteralWildcardMatcherTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ResourceLiteralWildcardMatcherTest {
+
+    @Test
+    public void testMatcher() {
+        assertTrue(ResourceLiteralWildcardMatcher.match("Topic:*", "Topic:topic-1"));
+        assertFalse(ResourceLiteralWildcardMatcher.match("Group:*", "Topic:topic-1"));
+        assertFalse(ResourceLiteralWildcardMatcher.match("Topic:topic-1", "Topic:*"));
+    }
+}

--- a/src/test/resources/acl_validation_fails.json
+++ b/src/test/resources/acl_validation_fails.json
@@ -1,0 +1,8 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^pass-3$",
+    "operation": "^Read$",
+    "permission_type": "ALLOW"
+  }
+]

--- a/src/test/resources/acls_resource_literal_match.json
+++ b/src/test/resources/acls_resource_literal_match.json
@@ -1,0 +1,21 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^(user1)$",
+    "operation": "^(.*)$",
+    "resource_literal": "Topic:topic-1"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^(user2)$",
+    "operation": "^(.*)$",
+    "resource_literal": "Topic:topic-2",
+    "permission_type": "DENY"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^(user3)$",
+    "operation": "^(.*)$",
+    "resource_literal": "Topic:*"
+  }
+]

--- a/src/test/resources/acls_resource_prefix_match.json
+++ b/src/test/resources/acls_resource_prefix_match.json
@@ -1,0 +1,15 @@
+[
+  {
+    "principal_type": "User",
+    "principal": "^(user1)$",
+    "operation": "^(.*)$",
+    "resource_prefix": "Topic:groupA."
+  },
+  {
+    "principal_type": "User",
+    "principal": "^(user2)$",
+    "operation": "^(.*)$",
+    "resource_prefix": "Topic:groupB.",
+    "permission_type": "DENY"
+  }
+]


### PR DESCRIPTION
For this feature instead of adding a field `resourcePatternType` that distinguishes between literal, prefixed and regex (the one used in Aiven ACLs) matching, I added the fields `resourceLiteral` and `resourcePrefixed`. I did this way because we already had resource matching splito into `resourceRe` and `resourceRePattern` (the later used for backreference regex), and it felt natural (and more backward compatible) adding the new matching in the same way.

In the authorization method, to select between the proper resource matcher, it is used the one who is not null (as was done before my PR). This is a bit fragile by itself, for this reason I added the method `validate()` to verify that exactly one of the four resource matchers is not null. The validation is called by the constructor and by the decode class [AclJsonReader.java](https://github.com/Aiven-Open/auth-for-apache-kafka/pull/215/files#diff-e794138e22523cf4b2b534ee654815ac907ff2d54c75a06829a0c88a0c089285). 

The literal prefix needed a bit of work for the wildcard match because the wildcard rule is defined like `Topic:*` or `Group:*`, etc and the prefix must match the one of the action that we are authorizing, so for example:

| Rule  | Action | Result |
| ------------- | ------------- | --- |
| `Topic:*`  | `Topic:some-topic`  | `true` |
| `Topic:*`  | `Group:abcde`  | `false` |
| `Group:*`  | `Group:abcde`  | `true` |

I didn't want to introduce some big refactor so I added the class [ResourceLiteralWildcardMatcher.java](https://github.com/Aiven-Open/auth-for-apache-kafka/pull/215/files#diff-8f4e88671ba9812e563937cdd9cdc41765b03eca57632d53cfd9529b4c9ac646) to perform this operation, trying to keep it fast as possible. 