### PR TITLE
Return ACLs uses ALL operation as response if possible

### DIFF
--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclOperationsParser.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclOperationsParser.java
@@ -38,16 +38,7 @@ class AclOperationsParser {
 
         if (operationPattern.equals("^.*$") || operationPattern.equals("^(.*)$")) {
             return List.of(
-                AclOperation.READ,
-                AclOperation.WRITE,
-                AclOperation.CREATE,
-                AclOperation.DELETE,
-                AclOperation.ALTER,
-                AclOperation.DESCRIBE,
-                AclOperation.CLUSTER_ACTION,
-                AclOperation.DESCRIBE_CONFIGS,
-                AclOperation.ALTER_CONFIGS,
-                AclOperation.IDEMPOTENT_WRITE
+                AclOperation.ALL
             );
         }
 

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverterTest.java
@@ -189,20 +189,12 @@ public class AclAivenToNativeConverterTest {
         final List<ResourceType> expectedResourceTypes = List.of(
             ResourceType.TOPIC, ResourceType.GROUP, ResourceType.CLUSTER,
             ResourceType.TRANSACTIONAL_ID, ResourceType.DELEGATION_TOKEN);
-        final List<AclOperation> expectedAclOperations = List.of(
-            AclOperation.READ, AclOperation.WRITE, AclOperation.CREATE,
-            AclOperation.DELETE, AclOperation.ALTER, AclOperation.DESCRIBE,
-            AclOperation.CLUSTER_ACTION, AclOperation.DESCRIBE_CONFIGS,
-            AclOperation.ALTER_CONFIGS, AclOperation.IDEMPOTENT_WRITE);
         for (final var resourceType : expectedResourceTypes) {
-            for (final var aclOperation : expectedAclOperations) {
-                expected.add(new AclBinding(
+            expected.add(new AclBinding(
                     new ResourcePattern(resourceType, "*", PatternType.LITERAL),
-                    new AccessControlEntry("User:admin", "*", aclOperation, AclPermissionType.ALLOW))
-                );
-            }
+                    new AccessControlEntry("User:admin", "*", AclOperation.ALL, AclPermissionType.ALLOW)));
         }
-        assertThat(result).containsAll(expected);
+        assertThat(result).hasSameElementsAs(expected);
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/auth/nativeacls/AclOperationsParserTest.java
+++ b/src/test/java/io/aiven/kafka/auth/nativeacls/AclOperationsParserTest.java
@@ -64,16 +64,7 @@ public class AclOperationsParserTest {
     public final void parseAclOperationsGlobalWildcard(final String value) {
         assertThat(AclOperationsParser.parse(value))
             .containsExactly(
-                AclOperation.READ,
-                AclOperation.WRITE,
-                AclOperation.CREATE,
-                AclOperation.DELETE,
-                AclOperation.ALTER,
-                AclOperation.DESCRIBE,
-                AclOperation.CLUSTER_ACTION,
-                AclOperation.DESCRIBE_CONFIGS,
-                AclOperation.ALTER_CONFIGS,
-                AclOperation.IDEMPOTENT_WRITE
+                AclOperation.ALL
             );
     }
 


### PR DESCRIPTION
Return ACLs uses ALL operation as response if possible

Use Operation.ALL if possible When returning ACLs parsed out from regular expressions to reduce number of returned entries.