### PR TITLE
Support implicit describe operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Config file is watched for modifications and reloaded as necessary.
 
 ### AivenAclEntry
 
-Class implementing a single ACL entry verification. Principal, operation and
+Class implementing a single ACL entry verification. Principal and
 resource are expressed as regular expressions.
 
 Alternatively to straight regular expression for resource, AivenAclEntry can
@@ -18,6 +18,12 @@ avoid encoding separate rules for each project. Literal and prefixed matchers
 work as defined in the Apache Kafka documentation. Only one resource matcher can be
 specified per acl.
 
+Operations can be expressed as a list of operation names, or in deprecated mode
+as regular expression in `operation` field.  If both are defined, `operations`
+takes precedence.  For operations listed with operation names, also implicit Decribe
+is supported if Read, Write, Alter, or Delete is allowed, and implicit
+DescribeConfigs if AlterConfigs is allowed.
+
 Permission type allows to define the verification result in case of an ACL match.
 By default, the permission type is `ALLOW`.
 
@@ -27,7 +33,7 @@ A specific ACL entry can be hidden from public listing by setting hidden flag.
 
     [
         {
-            "operation": "^(.*)$",
+            "operations": ["All"],
             "principal": (
                 "^CN=(?<vmname>[a-z0-9-]+),OU=(?<nodeid>n[0-9]+),"
                 "O=00000000-0000-a000-1000-(500000000005|a00000000001|b00000000001|d00000000001),ST=vm$"
@@ -38,6 +44,7 @@ A specific ACL entry can be hidden from public listing by setting hidden flag.
             "hidden": true
         },
         {
+            "operations": ["Describe", "DescribeConfigs", "Read", "Write"],
             "operation": "^(Describe|DescribeConfigs|Read|Write)$",
             "principal": "^CN=(?<vmname>[a-z0-9-]+),OU=(?<nodeid>n[0-9]+),O=(?<projectid>[a-f0-9-]+),ST=vm$",
             "principal_type": "Prune",

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ jmh {
 }
 
 ext {
-    kafkaVersion = "2.8.0"
+    kafkaVersion = "3.6.0"
     mockitoVersion = "5.14.2"
 }
 

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
@@ -59,7 +59,6 @@ import io.aiven.kafka.auth.audit.Session;
 import io.aiven.kafka.auth.json.AivenAcl;
 import io.aiven.kafka.auth.json.reader.AclJsonReader;
 import io.aiven.kafka.auth.json.reader.JsonReaderException;
-import io.aiven.kafka.auth.nameformatters.LegacyOperationNameFormatter;
 import io.aiven.kafka.auth.nameformatters.LegacyResourceTypeNameFormatter;
 import io.aiven.kafka.auth.nativeacls.AclAivenToNativeConverter;
 
@@ -195,7 +194,7 @@ public class AivenAclAuthorizerV2 implements Authorizer {
             final String host = requestContext.clientAddress().getHostAddress();
             final boolean verdict = cacheReference.get().get(principal,
                                                              host,
-                                                             LegacyOperationNameFormatter.format(operation),
+                                                             operation,
                                                              resourceToCheck);
             final var authResult = verdict ? AuthorizationResult.ALLOWED : AuthorizationResult.DENIED;
 

--- a/src/main/java/io/aiven/kafka/auth/VerdictCache.java
+++ b/src/main/java/io/aiven/kafka/auth/VerdictCache.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
 import io.aiven.kafka.auth.json.AclPermissionType;
@@ -44,7 +45,7 @@ public class VerdictCache {
     public boolean get(
         final KafkaPrincipal principal,
         final String host,
-        final String operation,
+        final AclOperation operation,
         final String resource
     ) {
         final String principalType = principal.getPrincipalType();

--- a/src/main/java/io/aiven/kafka/auth/json/AclOperationType.java
+++ b/src/main/java/io/aiven/kafka/auth/json/AclOperationType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.json;
+
+public enum AclOperationType {
+    Unknown(org.apache.kafka.common.acl.AclOperation.UNKNOWN),
+    All(org.apache.kafka.common.acl.AclOperation.ALL),
+    Read(org.apache.kafka.common.acl.AclOperation.READ),
+    Write(org.apache.kafka.common.acl.AclOperation.WRITE),
+    Create1(org.apache.kafka.common.acl.AclOperation.CREATE),
+    Delete(org.apache.kafka.common.acl.AclOperation.DELETE),
+    Alter(org.apache.kafka.common.acl.AclOperation.ALTER),
+    Describe(org.apache.kafka.common.acl.AclOperation.DESCRIBE),
+    ClusterAction(org.apache.kafka.common.acl.AclOperation.CLUSTER_ACTION),
+    DescribeConfigs(org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS),
+    AlterConfigs(org.apache.kafka.common.acl.AclOperation.ALTER_CONFIGS),
+    IdempotentWrite(org.apache.kafka.common.acl.AclOperation.IDEMPOTENT_WRITE),
+    CreateTokens(org.apache.kafka.common.acl.AclOperation.CREATE_TOKENS),
+    DescribeTokens(org.apache.kafka.common.acl.AclOperation.DESCRIBE_TOKENS);
+
+    public final org.apache.kafka.common.acl.AclOperation nativeType;
+
+    AclOperationType(final org.apache.kafka.common.acl.AclOperation nativeType) {
+        this.nativeType = nativeType;
+    }
+}

--- a/src/main/java/io/aiven/kafka/auth/json/reader/AbstractJsonReader.java
+++ b/src/main/java/io/aiven/kafka/auth/json/reader/AbstractJsonReader.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import io.aiven.kafka.auth.json.AclOperationType;
 import io.aiven.kafka.auth.json.AclPermissionType;
 
 import com.google.gson.GsonBuilder;
@@ -37,6 +38,7 @@ public abstract class AbstractJsonReader<T> implements JsonReader<T> {
     protected final GsonBuilder gsonBuilder =
         new GsonBuilder()
             .registerTypeAdapter(Pattern.class, new RegexpJsonDeserializer())
+            .registerTypeAdapter(AclOperationType.class, new AclOperationTypeDeserializer())
             .registerTypeAdapter(AclPermissionType.class, new AclPermissionTypeDeserializer());
 
     protected AbstractJsonReader(final Path configFile) {
@@ -72,4 +74,19 @@ public abstract class AbstractJsonReader<T> implements JsonReader<T> {
         }
     }
 
+    protected static class AclOperationTypeDeserializer implements JsonDeserializer<AclOperationType> {
+        @Override
+        public AclOperationType deserialize(final JsonElement jsonElement,
+                                             final Type type,
+                                             final JsonDeserializationContext ctx) throws JsonParseException {
+            try {
+                if (jsonElement.isJsonNull()) {
+                    return AclOperationType.Unknown;
+                }
+                return AclOperationType.valueOf(jsonElement.getAsString());
+            } catch (final IllegalArgumentException e) {
+                throw new JsonParseException("Cannot deserialize operation type", e);
+            }
+        }
+    }
 }

--- a/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
+++ b/src/main/java/io/aiven/kafka/auth/nativeacls/AclAivenToNativeConverter.java
@@ -19,9 +19,11 @@ package io.aiven.kafka.auth.nativeacls;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclOperation;
 
 import io.aiven.kafka.auth.json.AivenAcl;
 
@@ -36,7 +38,11 @@ public class AclAivenToNativeConverter {
             return result;
         }
 
-        for (final var operation : AclOperationsParser.parse(aivenAcl.operationRe.pattern())) {
+        final Iterable<AclOperation> operations = aivenAcl.operations != null
+             ? aivenAcl.operations.stream().map(o -> o.nativeType).collect(Collectors.toList())
+             : AclOperationsParser.parse(aivenAcl.operationRe.pattern());
+
+        for (final var operation : operations) {
             final List<String> principals = AclPrincipalFormatter.parse(
                 aivenAcl.principalType, aivenAcl.principalRe.pattern()
             );

--- a/src/test/java/io/aiven/kafka/auth/json/AivenAclTest.java
+++ b/src/test/java/io/aiven/kafka/auth/json/AivenAclTest.java
@@ -16,6 +16,8 @@
 
 package io.aiven.kafka.auth.json;
 
+import org.apache.kafka.common.acl.AclOperation;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -38,11 +40,11 @@ public class AivenAclTest {
             false // hidden
         );
 
-        assertTrue(entry.match("User",  "CN=p_pass_s", "*", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=fail", "*", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=p_pass_s", "*", "Write", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=p_pass_s", "*", "Read", "Topic:fail"));
-        assertFalse(entry.match("NonUser", "CN=p_pass_s", "*", "Read", "Topic:p_pass_s"));
+        assertTrue(entry.match("User",  "CN=p_pass_s", "*", AclOperation.READ, "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=fail", "*", AclOperation.READ, "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=p_pass_s", "*", AclOperation.WRITE, "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=p_pass_s", "*", AclOperation.READ, "Topic:fail"));
+        assertFalse(entry.match("NonUser", "CN=p_pass_s", "*", AclOperation.READ, "Topic:p_pass_s"));
 
         // Test with principal undefined
         entry = new AivenAcl(
@@ -58,10 +60,10 @@ public class AivenAclTest {
             false // hidden
         );
 
-        assertTrue(entry.match("User", "CN=p_pass_s", "*", "Read", "Topic:p_pass_s"));
-        assertTrue(entry.match("NonUser", "CN=p_pass_s", "*", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=fail", "*", "Read", "Topic:p_pass_s"));
-        assertFalse(entry.match("User", "CN=p_pass_s", "*", "Read", "Topic:fail"));
+        assertTrue(entry.match("User", "CN=p_pass_s", "*", AclOperation.READ, "Topic:p_pass_s"));
+        assertTrue(entry.match("NonUser", "CN=p_pass_s", "*", AclOperation.READ, "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=fail", "*", AclOperation.READ, "Topic:p_pass_s"));
+        assertFalse(entry.match("User", "CN=p_pass_s", "*", AclOperation.READ, "Topic:fail"));
 
         // Test resources defined by pattern
         entry = new AivenAcl(
@@ -77,10 +79,10 @@ public class AivenAclTest {
             false // hidden
         );
 
-        assertTrue(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:p_user1_s"));
-        assertTrue(entry.match("User", "CN=p_user2_s", "*", "Read", "Topic:p_user2_s"));
-        assertFalse(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:p_user2_s"));
-        assertFalse(entry.match("User", "CN=p_user2_s", "*", "Read", "Topic:p_user1_s"));
+        assertTrue(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:p_user1_s"));
+        assertTrue(entry.match("User", "CN=p_user2_s", "*", AclOperation.READ, "Topic:p_user2_s"));
+        assertFalse(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:p_user2_s"));
+        assertFalse(entry.match("User", "CN=p_user2_s", "*", AclOperation.READ, "Topic:p_user1_s"));
 
         // Test resources defined by literal match
         entry = new AivenAcl(
@@ -96,8 +98,8 @@ public class AivenAclTest {
                 false // hidden
         );
 
-        assertTrue(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:^(]["));
-        assertFalse(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:wrong_topic"));
+        assertTrue(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:^(]["));
+        assertFalse(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:wrong_topic"));
 
 
         // Test resources defined by prefix match
@@ -113,11 +115,11 @@ public class AivenAclTest {
                 null, // permission type
                 false // hidden
         );
-        assertTrue(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:organizationA.topic1"));
-        assertTrue(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:organizationA.topic2"));
-        assertTrue(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:organizationA."));
-        assertFalse(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:organizationB.topic1"));
-        assertFalse(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:organizationA"));
-        assertFalse(entry.match("User", "CN=p_user1_s", "*", "Read", "Topic:AAAorganizationA."));
+        assertTrue(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:organizationA.topic1"));
+        assertTrue(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:organizationA.topic2"));
+        assertTrue(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:organizationA."));
+        assertFalse(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:organizationB.topic1"));
+        assertFalse(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:organizationA"));
+        assertFalse(entry.match("User", "CN=p_user1_s", "*", AclOperation.READ, "Topic:AAAorganizationA."));
     }
 }

--- a/src/test/java/io/aiven/kafka/auth/json/reader/AclJsonReaderTest.java
+++ b/src/test/java/io/aiven/kafka/auth/json/reader/AclJsonReaderTest.java
@@ -17,7 +17,9 @@
 package io.aiven.kafka.auth.json.reader;
 
 import java.io.File;
+import java.util.List;
 
+import io.aiven.kafka.auth.json.AclOperationType;
 import io.aiven.kafka.auth.json.AclPermissionType;
 import io.aiven.kafka.auth.json.AivenAcl;
 
@@ -38,29 +40,29 @@ public class AclJsonReaderTest {
         assertThat(acls).containsExactly(
             new AivenAcl("User", "^pass-3$", "*", "^Read$",
                 "^Topic:denied$", null, null, null, AclPermissionType.DENY, false),
-            new AivenAcl("User", "^pass-0$", "*", "^Read$",
+            new AivenAcl("User", "^pass-0$", "*", List.of(AclOperationType.Read),
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
             new AivenAcl("User", "^pass-1$", "*", "^Read$",
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-2$", "*", "^Read$",
+            new AivenAcl("User", "^pass-2$", "*", List.of(AclOperationType.Read),
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
             new AivenAcl("User", "^pass-3$", "*", "^Read$",
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-4$", "*", "^Read$",
+            new AivenAcl("User", "^pass-4$", "*", List.of(AclOperationType.Read),
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
             new AivenAcl("User", "^pass-5$", "*", "^Read$",
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-6$", "*", "^Read$",
+            new AivenAcl("User", "^pass-6$", "*", List.of(AclOperationType.Read),
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
             new AivenAcl("User", "^pass-7$", "*", "^Read$",
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
             new AivenAcl("User", "^pass-8$", "*", "^Read$",
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-9$", "*", "^Read$",
+            new AivenAcl("User", "^pass-9$", "*", List.of(AclOperationType.Read),
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
             new AivenAcl("User", "^pass-10$", "*", "^Read$",
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
-            new AivenAcl("User", "^pass-11$", "*", "^Read$",
+            new AivenAcl("User", "^pass-11$", "*", List.of(AclOperationType.Read),
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
             new AivenAcl("User", "^pass-12$", "*", "^Read$",
                 "^Topic:(.*)$", null, null, null, AclPermissionType.ALLOW, false),
@@ -114,4 +116,10 @@ public class AclJsonReaderTest {
         assertThrows(JsonParseException.class, jsonReader::read);
     }
 
+    @Test
+    public final void parseWrongOperations() {
+        final var path = new File(this.getClass().getResource("/acl_wrong_operations.json").getPath()).toPath();
+        final var jsonReader = new AclJsonReader(path);
+        assertThrows(JsonParseException.class, jsonReader::read);
+    }
 }

--- a/src/test/resources/acl_operations.json
+++ b/src/test/resources/acl_operations.json
@@ -1,0 +1,70 @@
+[
+    {
+        "principal_type": "User",
+        "principal": "^re_1$",
+        "operation": "^Read$",
+        "resource": "^Topic:topic1$"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^enum_1$",
+        "operations": ["Read"],
+        "resource": "^Topic:topic1$"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^implicit$",
+        "operation": "^(Read|Write|Alter|Delete)$",
+        "resource": "^Topic:implicit_describe_not_in_re$"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^implicit1$",
+        "operations": ["Read"],
+        "resource": "^Group:implicit_describe_read$"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^implicit1$",
+        "operations": ["Delete"],
+        "resource": "^Group:implicit_describe_delete$"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^implicit2$",
+        "operations": ["Alter"],
+        "resource": "^Topic:implicit_describe_alter$"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^implicit2$",
+        "operations": ["Write"],
+        "resource": "^Topic:implicit_describe_write$"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^implicit3$",
+        "operations": ["AlterConfigs"],
+        "resource": "^Topic:implicit_describe_alterconfigs$"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^implicit4$",
+        "operations": ["All"],
+        "resource": "^Topic:implicit_alterconfigs2$",
+        "permission_type": "ALLOW"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^implicit4$",
+        "operations": ["AlterConfigs"],
+        "resource": "^Topic:implicit_alterconfigs2$",
+        "permission_type": "DENY"
+    },
+    {
+        "principal_type": "User",
+        "principal": "^all$",
+        "operations": ["All"],
+        "resource": "^Topic:foobar$"
+    }
+]

--- a/src/test/resources/acl_wrong_operations.json
+++ b/src/test/resources/acl_wrong_operations.json
@@ -1,0 +1,8 @@
+[
+    {
+      "principal_type": "User",
+      "principal": "^p$",
+      "operations": ["Read", "Ring"],
+      "resource": "^(.*)$"
+    }
+  ]

--- a/src/test/resources/acls_deny.json
+++ b/src/test/resources/acls_deny.json
@@ -2,7 +2,7 @@
   {
     "principal_type": "User",
     "principal": "^(.*)$",
-    "operation": "^Read$",
+    "operations": ["Read"],
     "resource": "^Topic:(.*)$",
     "permission_type": "ALLOW"
   },

--- a/src/test/resources/acls_full.json
+++ b/src/test/resources/acls_full.json
@@ -9,7 +9,7 @@
   {
     "principal_type": "User",
     "principal": "^pass-0$",
-    "operation": "^Read$",
+    "operations": ["Read"],
     "resource": "^Topic:(.*)$"
   },
   {
@@ -21,7 +21,7 @@
   {
     "principal_type": "User",
     "principal": "^pass-2$",
-    "operation": "^Read$",
+    "operations": ["Read"],
     "resource": "^Topic:(.*)$"
   },
   {
@@ -33,7 +33,7 @@
   {
     "principal_type": "User",
     "principal": "^pass-4$",
-    "operation": "^Read$",
+    "operations": ["Read"],
     "resource": "^Topic:(.*)$"
   },
   {
@@ -45,7 +45,7 @@
   {
     "principal_type": "User",
     "principal": "^pass-6$",
-    "operation": "^Read$",
+    "operations": ["Read"],
     "resource": "^Topic:(.*)$"
   },
   {
@@ -63,7 +63,7 @@
   {
     "principal_type": "User",
     "principal": "^pass-9$",
-    "operation": "^Read$",
+    "operations": ["Read"],
     "resource": "^Topic:(.*)$"
   },
   {
@@ -75,7 +75,7 @@
   {
     "principal_type": "User",
     "principal": "^pass-11$",
-    "operation": "^Read$",
+    "operations": ["Read"],
     "resource": "^Topic:(.*)$"
   },
   {

--- a/src/test/resources/acls_host_match.json
+++ b/src/test/resources/acls_host_match.json
@@ -3,14 +3,14 @@
     "principal_type": "User",
     "principal": "^(.*)$",
     "host": "*",
-    "operation": "^(.*)$",
+    "operations": ["All"],
     "resource": "^Topic:topic-1$"
   },
   {
     "principal_type": "User",
     "principal": "^(.*)$",
     "host": "192.168.123.45",
-    "operation": "^(.*)$",
+    "operations": ["All"],
     "resource": "^Topic:topic-2$"
   },
   {

--- a/src/test/resources/acls_no_type.json
+++ b/src/test/resources/acls_no_type.json
@@ -1,7 +1,7 @@
 [
   {
     "principal": "^pass$",
-    "operation": "^Read$",
+    "operations": ["Read"],
     "resource": "^Topic:(.*)$"
   }
 ]

--- a/src/test/resources/acls_resource_literal_match.json
+++ b/src/test/resources/acls_resource_literal_match.json
@@ -8,14 +8,14 @@
   {
     "principal_type": "User",
     "principal": "^(user2)$",
-    "operation": "^(.*)$",
+    "operations": ["All"],
     "resource_literal": "Topic:topic-2",
     "permission_type": "DENY"
   },
   {
     "principal_type": "User",
     "principal": "^(user3)$",
-    "operation": "^(.*)$",
+    "operations": ["All"],
     "resource_literal": "Topic:*"
   }
 ]

--- a/src/test/resources/acls_resource_prefix_match.json
+++ b/src/test/resources/acls_resource_prefix_match.json
@@ -8,7 +8,7 @@
   {
     "principal_type": "User",
     "principal": "^(user2)$",
-    "operation": "^(.*)$",
+    "operations": ["All"],
     "resource_prefix": "Topic:groupB.",
     "permission_type": "DENY"
   }


### PR DESCRIPTION
This implements also implied allow describe + allow describe configs feature as defined by org.apache.kafka.common.acl.AclOperation class.

This mode works only if operations are defined in new mode as list of strings instead of regular expression.

Some of the existing tests have been changed format to ensure backward compatibility by having tests using both formats.

To support all current Kafka operations, Kafka dependency is bumped to 3.6.