### PR TITLE
Fix: escape principal and resource tag value in authorizer metrics

### DIFF
--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerMetrics.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerMetrics.java
@@ -141,15 +141,15 @@ public class AivenAclAuthorizerMetrics {
                     metrics.metricInstance(
                         authOpDenyRateByOperationResourcePrincipal,
                         "operation", operation.name(),
-                        "resource", resourcePattern.name(),
-                        "principal", principal.getName()),
+                        "resource", EscapeTagValue.apply(resourcePattern.name()),
+                        "principal", EscapeTagValue.apply(principal.getName())),
                     new Rate());
                 authOpDenySensor.add(
                     metrics.metricInstance(
                         authOpDenyTotalByOperationResourcePrincipal,
                         "operation", operation.name(),
-                        "resource", resourcePattern.name(),
-                        "principal", principal.getName()),
+                        "resource", EscapeTagValue.apply(resourcePattern.name()),
+                        "principal", EscapeTagValue.apply(principal.getName())),
                     new CumulativeCount());
                 authOpDenySensor.record();
                 break;

--- a/src/main/java/io/aiven/kafka/auth/EscapeTagValue.java
+++ b/src/main/java/io/aiven/kafka/auth/EscapeTagValue.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth;
+
+public class EscapeTagValue {
+    public static String apply(final String value) {
+        return value
+            .replace(",", "\\,")
+            .replace("=", "\\=")
+            .replace(" ", "\\ ");
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/EscapeTagValueTest.java
+++ b/src/test/java/io/aiven/kafka/auth/EscapeTagValueTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EscapeTagValueTest {
+
+    @Test
+    void testEscape() throws Exception {
+        assertEquals("abcd\\,efgh", EscapeTagValue.apply("abcd,efgh"));
+        assertEquals("abcd\\=efgh", EscapeTagValue.apply("abcd=efgh"));
+        assertEquals("abcd\\ efgh", EscapeTagValue.apply("abcd efgh"));
+        assertEquals("ab\\,cd\\=ef\\ gh", EscapeTagValue.apply("ab,cd=ef gh"));
+        assertEquals("abcdefgh", EscapeTagValue.apply("abcdefgh"));
+    }
+}


### PR DESCRIPTION
Escape commas, spaces and equals because in the exported JMX metrics to avoid parsing errors.