### PR TITLE
Fix sensor usage with tags

### DIFF
--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerMetrics.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerMetrics.java
@@ -121,38 +121,49 @@ public class AivenAclAuthorizerMetrics {
         final KafkaPrincipal principal
     ) {
         switch (result) {
-            case ALLOWED:
-                authOpAllowSensor.add(
-                    metrics.metricInstance(
-                        authOpAllowRateByOperation,
-                        "operation", operation.name()
-                    ),
-                    new Rate());
-                authOpAllowSensor.add(
-                    metrics.metricInstance(
-                        authOpAllowTotalByOperation,
-                        "operation", operation.name()
-                    ),
-                    new CumulativeCount());
-                authOpAllowSensor.record();
+            case ALLOWED: {
+                final String sensorName = AUTH_OP_ALLOW + "," + operation.name();
+                Sensor s = metrics.getSensor(sensorName);
+                if (s == null) {
+                    s = metrics.sensor(sensorName, RecordingLevel.INFO, authOpAllowSensor);
+                    s.add(
+                            metrics.metricInstance(
+                                    authOpAllowRateByOperation,
+                                    "operation", operation.name()),
+                            new Rate());
+                    s.add(
+                            metrics.metricInstance(
+                                    authOpAllowTotalByOperation,
+                                    "operation", operation.name()),
+                            new CumulativeCount());
+                }
+                s.record();
                 break;
-            case DENIED:
-                authOpDenySensor.add(
-                    metrics.metricInstance(
-                        authOpDenyRateByOperationResourcePrincipal,
-                        "operation", operation.name(),
-                        "resource", EscapeTagValue.apply(resourcePattern.name()),
-                        "principal", EscapeTagValue.apply(principal.getName())),
-                    new Rate());
-                authOpDenySensor.add(
-                    metrics.metricInstance(
-                        authOpDenyTotalByOperationResourcePrincipal,
-                        "operation", operation.name(),
-                        "resource", EscapeTagValue.apply(resourcePattern.name()),
-                        "principal", EscapeTagValue.apply(principal.getName())),
-                    new CumulativeCount());
-                authOpDenySensor.record();
+            }
+            case DENIED: {
+                final String sensorName = AUTH_OP_DENY + "," + operation.name() + ","
+                        + resourcePattern.name() + "," + principal.getName();
+                Sensor s = metrics.getSensor(sensorName);
+                if (s == null) {
+                    s = metrics.sensor(sensorName, RecordingLevel.INFO, authOpDenySensor);
+                    s.add(
+                            metrics.metricInstance(
+                                    authOpDenyRateByOperationResourcePrincipal,
+                                    "operation", operation.name(),
+                                    "resource", EscapeTagValue.apply(resourcePattern.name()),
+                                    "principal", EscapeTagValue.apply(principal.getName())),
+                            new Rate());
+                    s.add(
+                            metrics.metricInstance(
+                                    authOpDenyTotalByOperationResourcePrincipal,
+                                    "operation", operation.name(),
+                                    "resource", EscapeTagValue.apply(resourcePattern.name()),
+                                    "principal", EscapeTagValue.apply(principal.getName())),
+                            new CumulativeCount());
+                }
+                s.record();
                 break;
+            }
             default: break;
         }
     }

--- a/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerMetricsTest.java
+++ b/src/test/java/io/aiven/kafka/auth/AivenAclAuthorizerMetricsTest.java
@@ -113,9 +113,17 @@ class AivenAclAuthorizerMetricsTest {
         assertThat(MBEAN_SERVER.getAttribute(metricMBean, "auth-ops-deny-total"))
             .isEqualTo(2.0);
 
+        // u2 has now rate
         {
             final var deniedByOpMBean = new ObjectName(name + ",operation=" + AclOperation.WRITE
                 + ",resource=t2,principal=u2");
+            assertThat(MBEAN_SERVER.getAttribute(deniedByOpMBean, "auth-ops-deny-total"))
+                .isEqualTo(1.0);
+        }
+        // u1 did not increase
+        {
+            final var deniedByOpMBean = new ObjectName(name + ",operation=" + AclOperation.WRITE
+                + ",resource=t1,principal=u1");
             assertThat(MBEAN_SERVER.getAttribute(deniedByOpMBean, "auth-ops-deny-total"))
                 .isEqualTo(1.0);
         }


### PR DESCRIPTION
Each combination of operation, resource and principal needs to use its own sensor so that other operations do not also increment metrics for another.

Metrics includes ExpireSensorTask which removes those sensors created here if not used anymore after some time.