### PR TITLE
feat: limit verdict cache size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docs/_build
 build/
 rpm/
 rpmbuild/
+bin
+.vscode

--- a/build.gradle
+++ b/build.gradle
@@ -82,12 +82,16 @@ dependencies {
     implementation "com.google.guava:guava:33.4.0-jre"
     implementation "com.google.code.gson:gson:2.11.0"
 
+    implementation "com.github.ben-manes.caffeine:caffeine:3.2.0"
+
     compileOnly "org.apache.kafka:kafka_2.12:${kafkaVersion}"
     compileOnly "org.slf4j:slf4j-api:1.7.36"
 
     testImplementation "org.apache.kafka:kafka_2.12:${kafkaVersion}"
 
     testImplementation "org.slf4j:slf4j-log4j12:1.7.36"
+
+    testImplementation 'org.openjdk.jol:jol-cli:0.17'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
     testImplementation "org.junit.jupiter:junit-jupiter:5.11.4"
@@ -125,6 +129,11 @@ jacoco {
 
 test {
     useJUnitPlatform()
+    testLogging {
+        events 'failed', 'skipped'
+        exceptionFormat 'full'
+    }
+    jvmArgs '-Djol.magicFieldOffset=true'
 }
 
 jar {

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerConfig.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerConfig.java
@@ -28,6 +28,7 @@ import io.aiven.kafka.auth.audit.AuditorAPI;
 import io.aiven.kafka.auth.audit.NoAuditor;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+import static org.apache.kafka.common.config.ConfigDef.Range.between;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 
 public final class AivenAclAuthorizerConfig extends AbstractConfig {
@@ -37,7 +38,13 @@ public final class AivenAclAuthorizerConfig extends AbstractConfig {
     private static final String LOG_DENIALS_CONF = PREFIX + "log.denials";
     private static final String CONFIG_REFRESH_CONF = PREFIX + "config.refresh.interval";
     private static final String LIST_ACLS_ENABLED_CONF = PREFIX + "list.acls.enabled";
-
+    
+    private static final String CACHE_MAX_SIZE_PERCENTAGE_CONF = PREFIX + "cache.max.size.percentage";
+    private static final String CACHE_MAX_SIZE_PERCENTAGE_DOC = 
+        "The maximum (estimated) size of the cache as a percentage of the heap size. The default value is 25%.";
+    private static final String CACHE_EXIRE_AFTER_ACCESS_MINUTES_CONF = PREFIX + "cache.expire.after.access.minutes";
+    private static final String CACHE_EXPIRE_AFTER_ACCESS_MINUTES_DOC = 
+        "The time after which the cache entries expire after last access in minutes. The default value is 60 minutes.";
 
     public static final String METRICS_NUM_SAMPLES_CONFIG = PREFIX
         + CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG;
@@ -118,6 +125,21 @@ public final class AivenAclAuthorizerConfig extends AbstractConfig {
                     Sensor.RecordingLevel.TRACE.toString()),
                 ConfigDef.Importance.LOW,
                 METRICS_RECORDING_LEVEL_DOC
+            )
+            .define(
+                CACHE_MAX_SIZE_PERCENTAGE_CONF,
+                ConfigDef.Type.INT,
+                25,
+                between(5, 50),
+                ConfigDef.Importance.LOW,
+                CACHE_MAX_SIZE_PERCENTAGE_DOC
+            )
+            .define(
+                CACHE_EXIRE_AFTER_ACCESS_MINUTES_CONF,
+                ConfigDef.Type.INT,
+                60,
+                ConfigDef.Importance.LOW,
+                CACHE_EXPIRE_AFTER_ACCESS_MINUTES_DOC
             );
     }
 
@@ -139,5 +161,13 @@ public final class AivenAclAuthorizerConfig extends AbstractConfig {
 
     public boolean listAclsEnabled() {
         return getBoolean(LIST_ACLS_ENABLED_CONF);
+    }
+
+    public int getCacheMaxSizePercentage() {
+        return getInt(CACHE_MAX_SIZE_PERCENTAGE_CONF);
+    }
+
+    public int getCacheExpireAfterAccess() {
+        return getInt(CACHE_EXIRE_AFTER_ACCESS_MINUTES_CONF);
     }
 }

--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
@@ -116,7 +116,8 @@ public class AivenAclAuthorizerV2 implements Authorizer {
 
         configFile = config.getConfigFile();
         final AclJsonReader jsonReader = new AclJsonReader(configFile.toPath());
-        cacheReference.set(VerdictCache.create(loadAcls(jsonReader)));
+        cacheReference.set(VerdictCache.create(loadAcls(jsonReader), config.getCacheMaxSizePercentage(),
+                config.getCacheExpireAfterAccess()));
         final AtomicReference<WatchKey> watchKeyReference = new AtomicReference<>(subscribeToAclChanges(configFile));
         scheduledExecutorService.scheduleWithFixedDelay(() -> {
             final WatchKey watchKey = watchKeyReference.get();
@@ -130,7 +131,8 @@ public class AivenAclAuthorizerV2 implements Authorizer {
                 }).findFirst().ifPresent(watchEvent -> {
                     LOGGER.info("{}: {}, Modified: {}",
                             watchEvent.kind(), watchEvent.context(), configFile.lastModified());
-                    cacheReference.set(VerdictCache.create(loadAcls(jsonReader)));
+                    cacheReference.set(VerdictCache.create(loadAcls(jsonReader), config.getCacheMaxSizePercentage(),
+                            config.getCacheExpireAfterAccess()));
                 });
                 if (!watchKey.reset()) {
                     watchKeyReference.compareAndSet(watchKey, subscribeToAclChanges(configFile));

--- a/src/main/java/io/aiven/kafka/auth/utils/ObjectSizeEstimator.java
+++ b/src/main/java/io/aiven/kafka/auth/utils/ObjectSizeEstimator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth.utils;
+
+public class ObjectSizeEstimator {
+
+    private ObjectSizeEstimator() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Estimates the size of a String object in Java.
+     * This is a rough estimate. The real size may vary based on JVM implementation and settings.
+     *
+     * @param s the String to estimate the size of
+     * @return estimated size in bytes
+     */
+    public static int estimateStringSize(final String s) {
+        /*
+        Example: "Hello, World!" (13 chars)
+        
+        String object:
+        - Header:            12 bytes
+        - Coder:             1 byte
+        - Hash:              4 bytes
+        - value reference:   4 bytes  (Compressed OOPs)
+        - Padding:           3 bytes  (for alignment)
+        ------------------------------------------------
+                             24 bytes
+
+        byte[] array:
+        - Header:            12 bytes
+        - Length field:      4 bytes
+        - Data:              13 bytes (1 byte per char, since Java 9 for Latin-1)
+        - Padding:           3 bytes (for 8-byte alignment)
+        ------------------------------------------------
+                             32 bytes
+        
+        Total:               56 bytes
+        */
+        if (s == null) {
+            return 0;
+        }
+        final int stringObjectSize = 24; // Object header + coder + hash + ref + alignment
+        int charArraySize = s.length() + 16; // 1 byte per char + header + length
+        charArraySize += (charArraySize % 8 == 0) ? 0 : (8 - (charArraySize % 8)); // Padding for alignment
+        return stringObjectSize + charArraySize; 
+    }
+
+    /**
+     * Estimates the size of a Boolean object in Java.
+     * This is a rough estimate. The real size may vary based on JVM implementation and settings.
+     *
+     * @param b the Boolean to estimate the size of
+     * @return estimated size in bytes
+     */
+    public static int estimateBooleanSize(final Boolean b) {
+        if (b == null) {
+            return 0;
+        }
+        return 12 + 4; // Object header + ref
+    }
+
+    /**
+     * Estimates the overhead of a cache entry in Java.
+     * This is a rough estimate. The real size may vary based on JVM implementation and settings.
+     *
+     * @return estimated size in bytes
+     */
+    public static int estimateEntryOverhead() {
+        return 12 + 4 + 4 + 4; // Object header + key ref + value ref + hash
+    }
+    
+}

--- a/src/test/java/io/aiven/kafka/auth/VerdictCacheTest.java
+++ b/src/test/java/io/aiven/kafka/auth/VerdictCacheTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+import io.aiven.kafka.auth.utils.ObjectSizeEstimator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openjdk.jol.info.GraphLayout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VerdictCacheTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "a", "Hello, World!", "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        "1234567890", "[]{}|;:'\"<>,./?`~!@#$%^&*()_+-=\\|" })
+    void testStringSizeEstimation(final String s) throws Exception {
+        final GraphLayout layout = GraphLayout.parseInstance(s);
+        final long size = layout.totalSize();
+        final long estimatedSize = ObjectSizeEstimator.estimateStringSize(s);
+        assertEquals(size, estimatedSize);
+    }
+
+    @Test
+    void testBooleanSizeEstimation() throws Exception {
+        final Boolean testBoolean = true;
+        final GraphLayout layout = GraphLayout.parseInstance(testBoolean);
+        final long size = layout.totalSize();
+        final long estimatedSize = ObjectSizeEstimator.estimateBooleanSize(testBoolean);
+        assertEquals(size, estimatedSize);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "25, 33",
+        "50, 20",
+        "100, 10",
+        "200, 7",
+    })
+    void testCacheEvictionBySize(final int sizeMB, final int errorTolerance) throws Exception {
+        final long maxHeapSize = Runtime.getRuntime().maxMemory();
+
+        final long cacheSizeBytes = sizeMB * 1024 * 1024;
+        final double cacheSizePercentage = ((double) cacheSizeBytes / maxHeapSize) * 100;
+
+        final VerdictCache cache = VerdictCache.create(Collections.emptyList(), cacheSizePercentage, 60);
+
+        final KafkaPrincipal principal = new KafkaPrincipal("User", "testUser");
+        final AclOperation operation = AclOperation.READ;
+        final String resource = "testResource";
+
+        long count = 0;
+        while (true) {
+            final String host = UUID.randomUUID().toString();
+            cache.get(principal, host, operation, resource);
+            count++;
+            if (cache.getEstimatedSizeBytes() >= cacheSizeBytes * 0.99) {
+                break;
+            }
+        }
+
+        var layout = GraphLayout.parseInstance(cache);
+        long size = layout.totalSize();
+        long estimatedSize = cache.getEstimatedSizeBytes();
+        double percentDifferenceEstimatedVsMeasured = ((double) Math.abs(size - estimatedSize) / estimatedSize) * 100;
+
+        // Allow margin of error. Error is greatest when the cache is small.
+        assertEquals(0, percentDifferenceEstimatedVsMeasured, errorTolerance);
+
+        // Add 100% more entries to the cache to see if it will evict entries based on size
+        for (var i = 0; i < count; i++) {
+            final String host = UUID.randomUUID().toString();
+            cache.get(principal, host, operation, resource);
+        }
+
+        layout = GraphLayout.parseInstance(cache);
+        size = layout.totalSize();
+        estimatedSize = cache.getEstimatedSizeBytes();
+        percentDifferenceEstimatedVsMeasured = ((double) Math.abs(size - estimatedSize) / estimatedSize) * 100;
+
+        // Allow margin of error. Error is greatest when the cache is small.
+        assertEquals(0, percentDifferenceEstimatedVsMeasured, errorTolerance);
+
+        // Check difference between desired size and measured size
+        final double percentDifferenceDesiredVsMeasured = 
+            ((double) Math.abs(cacheSizeBytes - estimatedSize) / estimatedSize) * 100;
+        
+        assertEquals(0, percentDifferenceDesiredVsMeasured, errorTolerance);
+    }
+
+}


### PR DESCRIPTION
Limits the VerdictCache size by removing unused keys (last access older than x minutes) and capping the total cache size to a percentage of the heap, preventing OOM. The cache size is estimated rather than precisely measured to avoid performance overhead.