### PR TITLE
Implement authorizeByResourceType efficiently

### DIFF
--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -7,13 +7,12 @@
         "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
     <suppress checks="VariableDeclarationUsageDistance" files=".*Test\.java"/>
-    <suppress checks="JavadocMethod" files=".*/test/java/.*/BenchmarkRunner\.java"/>
 
     <!-- FIXME will remove after cleaning the code -->
-    <suppress checks="CyclomaticComplexity" files="AivenAclAuthorizer.java" />
-    <suppress checks="ClassFanOutComplexity" files="AivenAclAuthorizer.java" />
     <suppress checks="ClassFanOutComplexity" files="AivenAclAuthorizerV2.java" />
-    <suppress checks="NPathComplexity" files="AivenAclAuthorizer.java" />
+    <suppress checks="NPathComplexity" files="AivenAclAuthorizerV2.java" />
+    <suppress checks="NCSS" files="AivenAclAuthorizerV2.java" />
+    <suppress checks="CyclomaticComplexity" files="AivenAclAuthorizerV2.java" />
     <suppress checks="MethodLength" files="AivenAclAuthorizerTest.java"/>
     <suppress checks="ClassFanOutComplexity" files="AivenAclAuthorizerV2Test.java"/>
     <suppress checks="CyclomaticComplexity" files="LegacyOperationNameFormatter.java" />

--- a/src/main/java/io/aiven/kafka/auth/VerdictCache.java
+++ b/src/main/java/io/aiven/kafka/auth/VerdictCache.java
@@ -97,6 +97,14 @@ public class VerdictCache {
         return Stream.concat(denyAclEntries.stream(), allowAclEntries.stream());
     }
 
+    public List<AivenAcl> getAllowAclEntries() {
+        return Collections.unmodifiableList(allowAclEntries);
+    }
+
+    public List<AivenAcl> getDenyAclEntries() {
+        return Collections.unmodifiableList(denyAclEntries);
+    }
+
     public static VerdictCache create(final List<AivenAcl> aclEntries, final double maxSizePercentage,
             final int expireAfterAccessMinutes) {
         if (aclEntries == null || aclEntries.isEmpty()) {

--- a/src/test/java/io/aiven/kafka/auth/AuthByResouceTypeTest.java
+++ b/src/test/java/io/aiven/kafka/auth/AuthByResouceTypeTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2025 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+import org.apache.kafka.server.authorizer.AuthorizerServerInfo;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthByResouceTypeTest {
+    @TempDir
+    Path tmpDir;
+    Path configFilePath;
+    final AivenAclAuthorizerV2 auth = new AivenAclAuthorizerV2();
+    Map<String, String> configs;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        configFilePath = tmpDir.resolve("acl.json");
+        configs = Map.of("aiven.acl.authorizer.configuration", configFilePath.toString(),
+                         "aiven.acl.authorizer.config.refresh.interval", "10");
+        auth.configure(configs);
+
+        Files.copy(this.getClass().getResourceAsStream("/test_acls_for_authorize_by_resource_type.json"),
+                   configFilePath);
+        startAuthorizer();
+    }
+
+    @AfterEach
+    void tearDown() {
+        auth.close();
+    }
+
+    private void startAuthorizer() {
+        final AuthorizerServerInfo serverInfo = mock(AuthorizerServerInfo.class);
+        when(serverInfo.endpoints()).thenReturn(List.of());
+        auth.start(serverInfo);
+    }
+
+    private AuthorizableRequestContext requestCtx(
+            final String principalType,
+            final String name) throws IOException {
+        return new RequestContext(
+                new RequestHeader(ApiKeys.METADATA, (short) 0, "some-client-id", 123),
+                "connection-id",
+                Inet4Address.getByName("127.0.0.1"),
+                new KafkaPrincipal(principalType, name),
+                new ListenerName("SSL"),
+                SecurityProtocol.SSL,
+                ClientInformation.EMPTY,
+                false);
+    }
+
+    static final class AuthByResourceTypeTestcase {
+        final String name;
+        final AclOperation operation;
+        final ResourceType resourceType;
+        final AuthorizationResult expectedResult;
+
+        public AuthByResourceTypeTestcase(final String name, final AclOperation operation,
+                                          final ResourceType resourceType, final AuthorizationResult expectedResult) {
+            this.name = name;
+            this.operation = operation;
+            this.resourceType = resourceType;
+            this.expectedResult = expectedResult;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    static Stream<AuthByResourceTypeTestcase> authByResouceTypeTestcaseProvider() {
+        return Stream.of(
+                new AuthByResourceTypeTestcase("test_user_no_acls", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.DENIED),
+                new AuthByResourceTypeTestcase("test_user_allow_some", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.ALLOWED),
+                new AuthByResourceTypeTestcase("test_user_deny_all", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.DENIED),
+                new AuthByResourceTypeTestcase("test_user_deny_prefix", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.DENIED),
+                new AuthByResourceTypeTestcase("test_user_allow_read", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.DENIED),
+                new AuthByResourceTypeTestcase("test_user_allow_all", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.ALLOWED),
+                new AuthByResourceTypeTestcase("test_user_allow_wildcard_host", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.ALLOWED),
+                new AuthByResourceTypeTestcase("test_user_allow_localhost", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.ALLOWED),
+                new AuthByResourceTypeTestcase("test_user_deny_host", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.DENIED),
+                new AuthByResourceTypeTestcase("test_user_deny_write", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.DENIED),
+                new AuthByResourceTypeTestcase("test_user_deny_write", AclOperation.READ, ResourceType.TOPIC,
+                        AuthorizationResult.ALLOWED),
+                new AuthByResourceTypeTestcase("test_user_deny_prefix_write", AclOperation.WRITE, ResourceType.TOPIC,
+                        AuthorizationResult.DENIED),
+                new AuthByResourceTypeTestcase("test_user_deny_prefix_write", AclOperation.READ, ResourceType.TOPIC,
+                        AuthorizationResult.ALLOWED)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("authByResouceTypeTestcaseProvider")
+    void authByResouceType(final AuthByResourceTypeTestcase testcase) throws IOException {
+        final AuthorizableRequestContext requestCtx = requestCtx("User", testcase.name);
+        assertThat(auth.authorizeByResourceType(requestCtx, testcase.operation, testcase.resourceType))
+            .isEqualTo(testcase.expectedResult);
+        assertThat(auth.default_authorizeByResourceType(requestCtx, testcase.operation, testcase.resourceType))
+            .isEqualTo(testcase.expectedResult);
+    }
+}

--- a/src/test/java/io/aiven/kafka/auth/AuthByResourceTypeBenchmark.java
+++ b/src/test/java/io/aiven/kafka/auth/AuthByResourceTypeBenchmark.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 Aiven Oy https://aiven.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.auth;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import org.apache.kafka.server.authorizer.AuthorizerServerInfo;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Authorizer::authorizeByResourceType benchmark compares AivenAclAuthorizerV2's
+ * implementation against Kafka's Authorizer default implementation.
+ *
+ * <p>Run with {@code gradlew jmh}
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class AuthByResourceTypeBenchmark {
+    Path tmpDir;
+    Path configFilePath;
+    final AivenAclAuthorizerV2 auth = new AivenAclAuthorizerV2();
+    Map<String, String> configs;
+
+    AuthorizableRequestContext testUserNoAcls;
+    AuthorizableRequestContext testUserAllowSome;
+    AuthorizableRequestContext testUserDenyAll;
+    AuthorizableRequestContext testUserDenyPrefix;
+    AuthorizableRequestContext testUserAllowRead;
+    AuthorizableRequestContext testUserAllowAll;
+    AuthorizableRequestContext testUserDenyWrite;
+    AuthorizableRequestContext testUserDenyPrefixWrite;
+
+    @Setup
+    public void setup() throws IOException {
+        tmpDir = Files.createTempDirectory("test-aiven-kafka-authorizer");
+        configFilePath = tmpDir.resolve("acl.json");
+        configs = Map.of(
+                "aiven.acl.authorizer.configuration", configFilePath.toString(),
+                "aiven.acl.authorizer.config.refresh.interval", "10");
+        auth.configure(configs);
+
+        Files.copy(this.getClass().getResourceAsStream("/benchmark_acls_for_authorize_by_resource_type.json"),
+                   configFilePath);
+        final AuthorizerServerInfo serverInfo = mock(AuthorizerServerInfo.class);
+        when(serverInfo.endpoints()).thenReturn(List.of());
+        auth.start(serverInfo);
+
+        configFilePath = Files.createTempDirectory("test-aiven-kafka-principal-builder")
+            .resolve("benchmark_config.json");
+        Files.copy(this.getClass().getResourceAsStream("/benchmark_config.json"), configFilePath);
+
+        testUserNoAcls = requestCtx("User", "test_user_no_acls");
+        testUserAllowSome = requestCtx("User", "test_user_allow_some");
+        testUserDenyAll = requestCtx("User", "test_user_deny_all");
+        testUserDenyPrefix = requestCtx("User", "test_user_deny_prefix");
+        testUserAllowRead = requestCtx("User", "test_user_allow_read");
+        testUserAllowAll = requestCtx("User", "test_user_allow_all");
+        testUserDenyWrite = requestCtx("User", "test_user_deny_write");
+        testUserDenyPrefixWrite = requestCtx("User", "test_user_deny_prefix_write");
+    }
+
+    @TearDown
+    public void tearDown() {
+        auth.close();
+    }
+
+    private AuthorizableRequestContext requestCtx(
+            final String principalType,
+            final String name) {
+        return new RequestContext(
+                new RequestHeader(ApiKeys.METADATA, (short) 0, "some-client-id", 123),
+                "connection-id",
+                InetAddress.getLoopbackAddress(),
+                new KafkaPrincipal(principalType, name),
+                new ListenerName("SSL"),
+                SecurityProtocol.SSL,
+                ClientInformation.EMPTY,
+                false);
+    }
+
+    @Benchmark
+    public void benchmarkAivenAclAuthorizerV2(final Blackhole bh) throws InterruptedException {
+        bh.consume(auth.authorizeByResourceType(testUserNoAcls, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.authorizeByResourceType(testUserAllowSome, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.authorizeByResourceType(testUserDenyAll, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.authorizeByResourceType(testUserDenyPrefix, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.authorizeByResourceType(testUserAllowRead, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.authorizeByResourceType(testUserAllowAll, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.authorizeByResourceType(testUserDenyWrite, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.authorizeByResourceType(testUserDenyWrite, AclOperation.READ,
+                ResourceType.TOPIC));
+        bh.consume(auth.authorizeByResourceType(testUserDenyPrefixWrite, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.authorizeByResourceType(testUserDenyPrefixWrite, AclOperation.READ,
+                ResourceType.TOPIC));
+    }
+
+    @Benchmark
+    public void benchmarkKafkaDefaultImpl(final Blackhole bh) throws InterruptedException {
+        bh.consume(auth.default_authorizeByResourceType(testUserNoAcls, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.default_authorizeByResourceType(testUserAllowSome, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.default_authorizeByResourceType(testUserDenyAll, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.default_authorizeByResourceType(testUserDenyPrefix, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.default_authorizeByResourceType(testUserAllowRead, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.default_authorizeByResourceType(testUserAllowAll, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.default_authorizeByResourceType(testUserDenyWrite, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.default_authorizeByResourceType(testUserDenyWrite, AclOperation.READ,
+                ResourceType.TOPIC));
+        bh.consume(auth.default_authorizeByResourceType(testUserDenyPrefixWrite, AclOperation.WRITE,
+                ResourceType.TOPIC));
+        bh.consume(auth.default_authorizeByResourceType(testUserDenyPrefixWrite, AclOperation.READ,
+                ResourceType.TOPIC));
+    }
+}

--- a/src/test/resources/benchmark_acls_for_authorize_by_resource_type.json
+++ b/src/test/resources/benchmark_acls_for_authorize_by_resource_type.json
@@ -1,0 +1,550 @@
+[
+    {
+        "operations": [
+            "All"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(myinternaloperator)$",
+        "principal_type": "User",
+        "resource": "^(.*)$"
+    },
+    {
+        "operations": [
+            "Alter",
+            "AlterConfigs",
+            "Delete",
+            "Read",
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(mysuperuser)$",
+        "principal_type": "User",
+        "resource": "^Topic:(.*)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-year\\-kind\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-car\\-person\\-request|week\\.time\\.way\\-year\\-woman\\-request|week\\.time\\.way\\-thing\\-kind\\-review\\-request|week\\.time\\.way\\-kind\\-review\\-request|week\\.time\\.kind\\-teacher|week\\.time\\.kind\\-version)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-year\\-kind\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-state|week\\.time\\.way\\-year\\-woman\\-request|week\\.time\\.way\\-thing\\-kind\\-review\\-request|week\\.time\\.way\\-kind\\-review\\-request|week\\.time\\.day\\-info|week\\.time\\.day\\-state|week\\.time\\.hand\\-info|week\\.time\\.hand\\-state|week\\.time\\.kind\\-teacher\\-result|week\\.time\\.art\\-day\\-friend\\-teacher)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-child\\-question\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.child\\-question\\-head)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-country\\-prworldrocessor)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-country|week\\.time\\.year\\-country\\-history|week\\.time\\.day\\-country|week\\.time\\.day\\-country\\-history|week\\.time\\.hand\\-country|week\\.time\\.hand\\-country\\-history|week\\.time\\.plate\\-country|week\\.time\\.plate\\-country\\-history)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-country\\-prworldrocessor)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-country\\-history\\-request|week\\.time\\.day\\-country\\-history\\-request|week\\.time\\.hand\\-country\\-history\\-request|week\\.time\\.plate\\-country\\-history\\-request|week\\.time\\.prworldrocessed\\-year\\-country|week\\.time\\.prworldrocessed\\-day\\-country|week\\.time\\.prworldrocessed\\-hand\\-country|week\\.time\\.prworldrocessed\\-plate\\-country)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-country\\-team)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-state|week\\.time\\.day\\-state|week\\.time\\.world\\-year\\-woman\\-request|week\\.time\\.world\\-day\\-woman\\-request|week\\.time\\.world\\-hand\\-woman\\-request|week\\.time\\.hand\\-state)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-country\\-team)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.world\\-year\\-woman\\-request|week\\.time\\.world\\-day\\-woman\\-request|week\\.time\\.world\\-hand\\-woman\\-request|week\\.time\\.prworldrocessed\\-year\\-country|week\\.time\\.prworldrocessed\\-day\\-country|week\\.time\\.prworldrocessed\\-hand\\-country|week\\.time\\.health\\-moment\\-family\\-people)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-family|week\\.time\\.year\\-car\\-person\\-request|week\\.time\\.problem\\-day\\-info\\-father|week\\.time\\.problem\\-hand\\-info\\-father|week\\.time\\.problem\\-foot\\-info\\-father|week\\.time\\.problem\\-plate\\-country|week\\.time\\.problem\\-operation\\-status|week\\.time\\.problem\\-level\\-school\\-force\\-father|week\\.time\\.problem\\-art\\-day\\-friend\\-teacher|week\\.time\\.kind\\-teacher|week\\.time\\.kind\\-version|week\\.time\\.health\\-moment\\-family\\-people)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-country|week\\.time\\.year\\-car\\-person\\-request|week\\.time\\.day\\-country|week\\.time\\.day\\-info|week\\.time\\.problem\\-day\\-info\\-father|week\\.time\\.problem\\-hand\\-info\\-father|week\\.time\\.problem\\-foot\\-info\\-father|week\\.time\\.problem\\-plate\\-country|week\\.time\\.problem\\-operation\\-status|week\\.time\\.problem\\-level\\-school\\-force\\-father|week\\.time\\.problem\\-art\\-day\\-friend\\-teacher|week\\.time\\.hand\\-country|week\\.time\\.hand\\-info|week\\.time\\.foot\\-info|week\\.time\\.plate\\-country|week\\.time\\.kind\\-teacher\\-result|week\\.time\\.level\\-school\\-force|week\\.time\\.art\\-day\\-friend\\-teacher)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-book \\-education\\-guy)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-family|week\\.time\\.year\\-family\\-student|week\\.time\\.child\\-question\\-head|week\\.time\\.plate\\-country|week\\.time\\.prworldrocessed\\-year\\-country|week\\.time\\.prworldrocessed\\-day\\-country|week\\.time\\.prworldrocessed\\-hand\\-country|week\\.time\\.prworldrocessed\\-plate\\-country|week\\.time\\.level\\-company\\-research\\-place|week\\.time\\.level\\-face\\-place|week\\.time\\.health\\-moment\\-family\\-people)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-side\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.level\\-company\\-research\\-place|week\\.time\\.level\\-face\\-place)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-law\\-student\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-family|week\\.time\\.prworldrocessed\\-plate\\-country)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-law\\-student\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-family\\-student)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-law\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-family|week\\.time\\.health\\-moment\\-family\\-people|week\\.time\\.health\\-moment\\-family\\-law\\-request)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-law\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-state|week\\.time\\.child\\-question\\-head|week\\.time\\.prworldrocessed\\-day\\-country|week\\.time\\.prworldrocessed\\-plate\\-country|week\\.time\\.health\\-moment\\-family\\-law\\-request)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-country\\-history|week\\.time\\.day\\-country\\-history|week\\.time\\.hand\\-country\\-history|week\\.time\\.plate\\-country\\-history|week\\.time\\.office\\-life\\-history\\-request)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-time\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.time\\.year\\-country\\-history\\-request|week\\.time\\.day\\-country\\-history\\-request|week\\.time\\.hand\\-country\\-history\\-request|week\\.time\\.plate\\-country\\-history\\-request|week\\.time\\.office\\-life\\-history\\-request)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-year\\-kind\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-car\\-person\\-request|week\\.minute\\.way\\-year\\-woman\\-request|week\\.minute\\.way\\-thing\\-kind\\-review\\-request|week\\.minute\\.way\\-kind\\-review\\-request|week\\.minute\\.kind\\-teacher|week\\.minute\\.kind\\-version)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-year\\-kind\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-state|week\\.minute\\.way\\-year\\-woman\\-request|week\\.minute\\.way\\-thing\\-kind\\-review\\-request|week\\.minute\\.way\\-kind\\-review\\-request|week\\.minute\\.day\\-info|week\\.minute\\.day\\-state|week\\.minute\\.hand\\-info|week\\.minute\\.hand\\-state|week\\.minute\\.kind\\-teacher\\-result|week\\.minute\\.art\\-day\\-friend\\-teacher)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-child\\-question\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.child\\-question\\-head)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-country\\-prworldrocessor)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-country|week\\.minute\\.year\\-country\\-history|week\\.minute\\.day\\-country|week\\.minute\\.day\\-country\\-history|week\\.minute\\.hand\\-country|week\\.minute\\.hand\\-country\\-history|week\\.minute\\.plate\\-country|week\\.minute\\.plate\\-country\\-history)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-country\\-prworldrocessor)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-country\\-history\\-request|week\\.minute\\.day\\-country\\-history\\-request|week\\.minute\\.hand\\-country\\-history\\-request|week\\.minute\\.plate\\-country\\-history\\-request|week\\.minute\\.prworldrocessed\\-year\\-country|week\\.minute\\.prworldrocessed\\-day\\-country|week\\.minute\\.prworldrocessed\\-hand\\-country|week\\.minute\\.prworldrocessed\\-plate\\-country)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-country\\-team)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-state|week\\.minute\\.day\\-state|week\\.minute\\.world\\-year\\-woman\\-request|week\\.minute\\.world\\-day\\-woman\\-request|week\\.minute\\.world\\-hand\\-woman\\-request|week\\.minute\\.hand\\-state)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-country\\-team)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.world\\-year\\-woman\\-request|week\\.minute\\.world\\-day\\-woman\\-request|week\\.minute\\.world\\-hand\\-woman\\-request|week\\.minute\\.prworldrocessed\\-year\\-country|week\\.minute\\.prworldrocessed\\-day\\-country|week\\.minute\\.prworldrocessed\\-hand\\-country|week\\.minute\\.health\\-moment\\-family\\-people)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-family|week\\.minute\\.year\\-car\\-person\\-request|week\\.minute\\.problem\\-day\\-info\\-father|week\\.minute\\.problem\\-hand\\-info\\-father|week\\.minute\\.problem\\-foot\\-info\\-father|week\\.minute\\.problem\\-plate\\-country|week\\.minute\\.problem\\-operation\\-status|week\\.minute\\.problem\\-level\\-school\\-force\\-father|week\\.minute\\.problem\\-art\\-day\\-friend\\-teacher|week\\.minute\\.kind\\-teacher|week\\.minute\\.kind\\-version|week\\.minute\\.health\\-moment\\-family\\-people)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-country|week\\.minute\\.year\\-car\\-person\\-request|week\\.minute\\.day\\-country|week\\.minute\\.day\\-info|week\\.minute\\.problem\\-day\\-info\\-father|week\\.minute\\.problem\\-hand\\-info\\-father|week\\.minute\\.problem\\-foot\\-info\\-father|week\\.minute\\.problem\\-plate\\-country|week\\.minute\\.problem\\-operation\\-status|week\\.minute\\.problem\\-level\\-school\\-force\\-father|week\\.minute\\.problem\\-art\\-day\\-friend\\-teacher|week\\.minute\\.hand\\-country|week\\.minute\\.hand\\-info|week\\.minute\\.foot\\-info|week\\.minute\\.plate\\-country|week\\.minute\\.kind\\-teacher\\-result|week\\.minute\\.level\\-school\\-force|week\\.minute\\.art\\-day\\-friend\\-teacher)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-book \\-education\\-guy)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-family|week\\.minute\\.year\\-family\\-student|week\\.minute\\.child\\-question\\-head|week\\.minute\\.plate\\-country|week\\.minute\\.prworldrocessed\\-year\\-country|week\\.minute\\.prworldrocessed\\-day\\-country|week\\.minute\\.prworldrocessed\\-hand\\-country|week\\.minute\\.prworldrocessed\\-plate\\-country|week\\.minute\\.level\\-company\\-research\\-place|week\\.minute\\.level\\-face\\-place|week\\.minute\\.health\\-moment\\-family\\-people)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-side\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.level\\-company\\-research\\-place|week\\.minute\\.level\\-face\\-place)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-law\\-student\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-family|week\\.minute\\.prworldrocessed\\-plate\\-country)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-law\\-student\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-family\\-student)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-law\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-family|week\\.minute\\.health\\-moment\\-family\\-people|week\\.minute\\.health\\-moment\\-family\\-law\\-request)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-law\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-state|week\\.minute\\.child\\-question\\-head|week\\.minute\\.prworldrocessed\\-day\\-country|week\\.minute\\.prworldrocessed\\-plate\\-country|week\\.minute\\.health\\-moment\\-family\\-law\\-request)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-country\\-history|week\\.minute\\.day\\-country\\-history|week\\.minute\\.hand\\-country\\-history|week\\.minute\\.plate\\-country\\-history|week\\.minute\\.office\\-life\\-history\\-request)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-minute\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.minute\\.year\\-country\\-history\\-request|week\\.minute\\.day\\-country\\-history\\-request|week\\.minute\\.hand\\-country\\-history\\-request|week\\.minute\\.plate\\-country\\-history\\-request|week\\.minute\\.office\\-life\\-history\\-request)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-year\\-kind\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-car\\-person\\-request|week\\.test\\.way\\-year\\-woman\\-request|week\\.test\\.way\\-thing\\-kind\\-review\\-request|week\\.test\\.way\\-kind\\-review\\-request|week\\.test\\.kind\\-teacher|week\\.test\\.kind\\-version)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-year\\-kind\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-state|week\\.test\\.way\\-year\\-woman\\-request|week\\.test\\.way\\-thing\\-kind\\-review\\-request|week\\.test\\.way\\-kind\\-review\\-request|week\\.test\\.day\\-info|week\\.test\\.day\\-state|week\\.test\\.hand\\-info|week\\.test\\.hand\\-state|week\\.test\\.kind\\-teacher\\-result|week\\.test\\.art\\-day\\-friend\\-teacher)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-child\\-question\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.child\\-question\\-head)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-country\\-prworldrocessor)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-country|week\\.test\\.year\\-country\\-history|week\\.test\\.day\\-country|week\\.test\\.day\\-country\\-history|week\\.test\\.hand\\-country|week\\.test\\.hand\\-country\\-history|week\\.test\\.plate\\-country|week\\.test\\.plate\\-country\\-history)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-country\\-prworldrocessor)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-country\\-history\\-request|week\\.test\\.day\\-country\\-history\\-request|week\\.test\\.hand\\-country\\-history\\-request|week\\.test\\.plate\\-country\\-history\\-request|week\\.test\\.prworldrocessed\\-year\\-country|week\\.test\\.prworldrocessed\\-day\\-country|week\\.test\\.prworldrocessed\\-hand\\-country|week\\.test\\.prworldrocessed\\-plate\\-country)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-country\\-team)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-state|week\\.test\\.day\\-state|week\\.test\\.world\\-year\\-woman\\-request|week\\.test\\.world\\-day\\-woman\\-request|week\\.test\\.world\\-hand\\-woman\\-request|week\\.test\\.hand\\-state)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-country\\-team)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.world\\-year\\-woman\\-request|week\\.test\\.world\\-day\\-woman\\-request|week\\.test\\.world\\-hand\\-woman\\-request|week\\.test\\.prworldrocessed\\-year\\-country|week\\.test\\.prworldrocessed\\-day\\-country|week\\.test\\.prworldrocessed\\-hand\\-country|week\\.test\\.health\\-moment\\-family\\-people)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-family|week\\.test\\.year\\-car\\-person\\-request|week\\.test\\.problem\\-day\\-info\\-father|week\\.test\\.problem\\-hand\\-info\\-father|week\\.test\\.problem\\-foot\\-info\\-father|week\\.test\\.problem\\-plate\\-country|week\\.test\\.problem\\-operation\\-status|week\\.test\\.problem\\-level\\-school\\-force\\-father|week\\.test\\.problem\\-art\\-day\\-friend\\-teacher|week\\.test\\.kind\\-teacher|week\\.test\\.kind\\-version|week\\.test\\.health\\-moment\\-family\\-people)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-country|week\\.test\\.year\\-car\\-person\\-request|week\\.test\\.day\\-country|week\\.test\\.day\\-info|week\\.test\\.problem\\-day\\-info\\-father|week\\.test\\.problem\\-hand\\-info\\-father|week\\.test\\.problem\\-foot\\-info\\-father|week\\.test\\.problem\\-plate\\-country|week\\.test\\.problem\\-operation\\-status|week\\.test\\.problem\\-level\\-school\\-force\\-father|week\\.test\\.problem\\-art\\-day\\-friend\\-teacher|week\\.test\\.hand\\-country|week\\.test\\.hand\\-info|week\\.test\\.foot\\-info|week\\.test\\.plate\\-country|week\\.test\\.kind\\-teacher\\-result|week\\.test\\.level\\-school\\-force|week\\.test\\.art\\-day\\-friend\\-teacher)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-book \\-education\\-guy)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-family|week\\.test\\.year\\-family\\-student|week\\.test\\.child\\-question\\-head|week\\.test\\.plate\\-country|week\\.test\\.prworldrocessed\\-year\\-country|week\\.test\\.prworldrocessed\\-day\\-country|week\\.test\\.prworldrocessed\\-hand\\-country|week\\.test\\.prworldrocessed\\-plate\\-country|week\\.test\\.level\\-company\\-research\\-place|week\\.test\\.level\\-face\\-place|week\\.test\\.health\\-moment\\-family\\-people)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-side\\-problem)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.level\\-company\\-research\\-place|week\\.test\\.level\\-face\\-place)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-law\\-student\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-family|week\\.test\\.prworldrocessed\\-plate\\-country)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-law\\-student\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-family\\-student)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-law\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-family|week\\.test\\.health\\-moment\\-family\\-people|week\\.test\\.health\\-moment\\-family\\-law\\-request)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-law\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-state|week\\.test\\.child\\-question\\-head|week\\.test\\.prworldrocessed\\-day\\-country|week\\.test\\.prworldrocessed\\-plate\\-country|week\\.test\\.health\\-moment\\-family\\-law\\-request)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-country\\-history|week\\.test\\.day\\-country\\-history|week\\.test\\.hand\\-country\\-history|week\\.test\\.plate\\-country\\-history|week\\.test\\.office\\-life\\-history\\-request)$"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(week\\-test\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(week\\.test\\.year\\-country\\-history\\-request|week\\.test\\.day\\-country\\-history\\-request|week\\.test\\.hand\\-country\\-history\\-request|week\\.test\\.plate\\-country\\-history\\-request|week\\.test\\.office\\-life\\-history\\-request)$"
+    },
+    {
+        "operations": [
+            "Describe",
+            "DescribeConfigs"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(mysuperuser|week\\-time\\-year\\-kind\\-reason|week\\-time\\-child\\-question\\-problem|week\\-time\\-country\\-prworldrocessor|week\\-time\\-country\\-team|week\\-time\\-problem|week\\-time\\-book \\-education\\-guy|week\\-time\\-side\\-problem|week\\-time\\-law\\-student\\-reason|week\\-time\\-law\\-reason|week\\-time\\-level\\-study\\-reason|week\\-minute\\-year\\-kind\\-reason|week\\-minute\\-child\\-question\\-problem|week\\-minute\\-country\\-prworldrocessor|week\\-minute\\-country\\-team|week\\-minute\\-problem|week\\-minute\\-book \\-education\\-guy|week\\-minute\\-side\\-problem|week\\-minute\\-law\\-student\\-reason|week\\-minute\\-law\\-reason|week\\-minute\\-level\\-study\\-reason|week\\-test\\-year\\-kind\\-reason|week\\-test\\-child\\-question\\-problem|week\\-test\\-country\\-prworldrocessor|week\\-test\\-country\\-team|week\\-test\\-problem|week\\-test\\-book \\-education\\-guy|week\\-test\\-side\\-problem|week\\-test\\-law\\-student\\-reason|week\\-test\\-law\\-reason|week\\-test\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Topic:(.*)$"
+    },
+    {
+        "operations": [
+            "Delete",
+            "Describe",
+            "Read"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(mysuperuser|week\\-time\\-year\\-kind\\-reason|week\\-time\\-country\\-prworldrocessor|week\\-time\\-country\\-team|week\\-time\\-problem|week\\-time\\-book \\-education\\-guy|week\\-time\\-law\\-student\\-reason|week\\-time\\-law\\-reason|week\\-time\\-level\\-study\\-reason|week\\-minute\\-year\\-kind\\-reason|week\\-minute\\-country\\-prworldrocessor|week\\-minute\\-country\\-team|week\\-minute\\-problem|week\\-minute\\-book \\-education\\-guy|week\\-minute\\-law\\-student\\-reason|week\\-minute\\-law\\-reason|week\\-minute\\-level\\-study\\-reason|week\\-test\\-year\\-kind\\-reason|week\\-test\\-country\\-prworldrocessor|week\\-test\\-country\\-team|week\\-test\\-problem|week\\-test\\-book \\-education\\-guy|week\\-test\\-law\\-student\\-reason|week\\-test\\-law\\-reason|week\\-test\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Group:(.*)$"
+    },
+    {
+        "operations": [
+            "Describe"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(mysuperuser|week\\-time\\-year\\-kind\\-reason|week\\-time\\-country\\-prworldrocessor|week\\-time\\-country\\-team|week\\-time\\-problem|week\\-time\\-book \\-education\\-guy|week\\-time\\-law\\-student\\-reason|week\\-time\\-law\\-reason|week\\-time\\-level\\-study\\-reason|week\\-minute\\-year\\-kind\\-reason|week\\-minute\\-country\\-prworldrocessor|week\\-minute\\-country\\-team|week\\-minute\\-problem|week\\-minute\\-book \\-education\\-guy|week\\-minute\\-law\\-student\\-reason|week\\-minute\\-law\\-reason|week\\-minute\\-level\\-study\\-reason|week\\-test\\-year\\-kind\\-reason|week\\-test\\-country\\-prworldrocessor|week\\-test\\-country\\-team|week\\-test\\-problem|week\\-test\\-book \\-education\\-guy|week\\-test\\-law\\-student\\-reason|week\\-test\\-law\\-reason|week\\-test\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Cluster:(.*)$"
+    },
+    {
+        "operations": [
+            "Describe",
+            "Write"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(mysuperuser|week\\-time\\-year\\-kind\\-reason|week\\-time\\-child\\-question\\-problem|week\\-time\\-country\\-prworldrocessor|week\\-time\\-country\\-team|week\\-time\\-problem|week\\-time\\-side\\-problem|week\\-time\\-law\\-student\\-reason|week\\-time\\-law\\-reason|week\\-time\\-level\\-study\\-reason|week\\-minute\\-year\\-kind\\-reason|week\\-minute\\-child\\-question\\-problem|week\\-minute\\-country\\-prworldrocessor|week\\-minute\\-country\\-team|week\\-minute\\-problem|week\\-minute\\-side\\-problem|week\\-minute\\-law\\-student\\-reason|week\\-minute\\-law\\-reason|week\\-minute\\-level\\-study\\-reason|week\\-test\\-year\\-kind\\-reason|week\\-test\\-child\\-question\\-problem|week\\-test\\-country\\-prworldrocessor|week\\-test\\-country\\-team|week\\-test\\-problem|week\\-test\\-side\\-problem|week\\-test\\-law\\-student\\-reason|week\\-test\\-law\\-reason|week\\-test\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^TransactionalId:(.*)$"
+    },
+    {
+        "operations": [
+            "IdempotentWrite"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(mysuperuser|week\\-time\\-year\\-kind\\-reason|week\\-time\\-child\\-question\\-problem|week\\-time\\-country\\-prworldrocessor|week\\-time\\-country\\-team|week\\-time\\-problem|week\\-time\\-side\\-problem|week\\-time\\-law\\-student\\-reason|week\\-time\\-law\\-reason|week\\-time\\-level\\-study\\-reason|week\\-minute\\-year\\-kind\\-reason|week\\-minute\\-child\\-question\\-problem|week\\-minute\\-country\\-prworldrocessor|week\\-minute\\-country\\-team|week\\-minute\\-problem|week\\-minute\\-side\\-problem|week\\-minute\\-law\\-student\\-reason|week\\-minute\\-law\\-reason|week\\-minute\\-level\\-study\\-reason|week\\-test\\-year\\-kind\\-reason|week\\-test\\-child\\-question\\-problem|week\\-test\\-country\\-prworldrocessor|week\\-test\\-country\\-team|week\\-test\\-problem|week\\-test\\-side\\-problem|week\\-test\\-law\\-student\\-reason|week\\-test\\-law\\-reason|week\\-test\\-level\\-study\\-reason)$",
+        "principal_type": "User",
+        "resource": "^Cluster:(.*)$"
+    },
+    {
+        "operations": [
+            "Create"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(mysuperuser)$",
+        "principal_type": "User",
+        "resource": "^(Cluster|Topic):(.*)$"
+    },
+    {
+        "operations": [
+            "DescribeConfigs"
+        ],
+        "permission_type": "ALLOW",
+        "principal": "^(.*)$",
+        "principal_type": "User",
+        "resource": "^Cluster:(.*)$"
+    }
+]

--- a/src/test/resources/test_acls_for_authorize_by_resource_type.json
+++ b/src/test/resources/test_acls_for_authorize_by_resource_type.json
@@ -1,0 +1,140 @@
+[
+    {
+        "operations": [
+            "Write"
+        ],
+        "principal": "^(test_user_allow_some)$",
+        "principal_type": "User",
+        "resource": "^Topic:(some)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "principal": "^(test_user_allow_some)$",
+        "principal_type": "User",
+        "resource": "^Topic:(deniedtopic)$",
+        "permission_type": "DENY"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "principal": "^(test_user_deny_prefix)$",
+        "principal_type": "User",
+        "resource": "^Topic:(prefix\\.something(.*))$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "principal": "^(test_user_deny_prefix)$",
+        "principal_type": "User",
+        "resource": "^Topic:(prefix(.*))$",
+        "permission_type": "DENY"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "principal": "^(test_user_deny_all)$",
+        "principal_type": "User",
+        "resource": "^Topic:(some)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "principal": "^(test_user_deny_all)$",
+        "principal_type": "User",
+        "resource": "^Topic:(.*)$",
+        "permission_type": "DENY"
+    },
+    {
+        "operations": [
+            "Read"
+        ],
+        "principal": "^(test_user_allow_read)$",
+        "principal_type": "User",
+        "resource": "^Topic:(.*)$"
+    },
+    {
+        "operations": [
+            "All"
+        ],
+        "principal": "^(test_user_allow_all)$",
+        "principal_type": "User",
+        "resource": "^Topic:(.*)$"
+    },
+    {
+        "operations": [
+            "All"
+        ],
+        "principal": "^(test_user_allow_wildcard_host)$",
+        "principal_type": "User",
+        "host": "*",
+        "resource": "^Topic:(.*)$"
+    },
+    {
+        "operations": [
+            "All"
+        ],
+        "principal": "^(test_user_allow_localhost)$",
+        "principal_type": "User",
+        "host": "*",
+        "resource": "^Topic:(.*)$"
+    },
+    {
+        "operations": [
+            "All"
+        ],
+        "principal": "^(test_user_deny_host)$",
+        "principal_type": "User",
+        "host": "*",
+        "resource": "^Topic:(.*)$"
+    },
+    {
+        "operations": [
+            "All"
+        ],
+        "principal": "^(test_user_deny_host)$",
+        "principal_type": "User",
+        "host": "127.0.0.1",
+        "resource": "^Topic:(.*)$",
+        "permission_type": "DENY"
+    },
+    {
+        "operations": [
+            "All"
+        ],
+        "principal": "^(test_user_deny_write)$",
+        "principal_type": "User",
+        "resource": "^Topic:(fixedtopic)$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "principal": "^(test_user_deny_write)$",
+        "principal_type": "User",
+        "resource": "^Topic:(fixedtopic)$",
+        "permission_type": "DENY"
+    },
+    {
+        "operations": [
+            "All"
+        ],
+        "principal": "^(test_user_deny_prefix_write)$",
+        "principal_type": "User",
+        "resource": "^Topic:(prefix\\.foo\\.(.*))$"
+    },
+    {
+        "operations": [
+            "Write"
+        ],
+        "principal": "^(test_user_deny_prefix_write)$",
+        "principal_type": "User",
+        "resource": "^Topic:(prefix(.*))$",
+        "permission_type": "DENY"
+    }
+]


### PR DESCRIPTION
Add implementation for `KafkaAuthorizer::authorizeByResourceType` that does not convert all ACL rules into Kafka format for authorization rule evaluation to improve performance.
    
The method implemented over default implementation follows the structure and logic of the default implementation without making conversion process.  The semantics are followed, but given that this authorizer also implements possibility of full regex matching instead of only prefixed matching, there might be special cases where semantics are undefined in specifying KIPs.
    
There is also performance test for comparing against Kafka's default implementation.
