### PR TITLE
Ignore host from cache key when not needed by rules

### DIFF
--- a/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
+++ b/src/main/java/io/aiven/kafka/auth/AivenAclAuthorizerV2.java
@@ -284,4 +284,8 @@ public class AivenAclAuthorizerV2 implements Authorizer {
             return List.of();
         }
     }
+
+    final long getEstimatedCacheSizeEntries() {
+        return cacheReference.get().getEstimatesSizeEntries();
+    }
 }

--- a/src/test/java/io/aiven/kafka/auth/VerdictCacheTest.java
+++ b/src/test/java/io/aiven/kafka/auth/VerdictCacheTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 
+import io.aiven.kafka.auth.json.AivenAcl;
 import io.aiven.kafka.auth.utils.ObjectSizeEstimator;
 
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,11 @@ class VerdictCacheTest {
         final long cacheSizeBytes = sizeMB * 1024 * 1024;
         final double cacheSizePercentage = ((double) cacheSizeBytes / maxHeapSize) * 100;
 
-        final VerdictCache cache = VerdictCache.create(Collections.emptyList(), cacheSizePercentage, 60);
+        final VerdictCache cache = VerdictCache.create(
+            Collections.singletonList(
+                new AivenAcl("User", "^(.*)$", "10.0.0.1", "^(.*)$",
+                    "^Topic:(.*)$", null, null, null, null, false)),
+            cacheSizePercentage, 60);
 
         final KafkaPrincipal principal = new KafkaPrincipal("User", "testUser");
         final AclOperation operation = AclOperation.READ;

--- a/src/test/resources/acls_host_match.json
+++ b/src/test/resources/acls_host_match.json
@@ -16,6 +16,13 @@
   {
     "principal_type": "User",
     "principal": "^(.*)$",
+    "host": "*",
+    "operations": ["All"],
+    "resource": "^Topic:topic-3$"
+  },
+  {
+    "principal_type": "User",
+    "principal": "^(.*)$",
     "host": "192.168.123.47",
     "operation": "^(.*)$",
     "resource": "^Topic:topic-1$",


### PR DESCRIPTION
If all ACL rules ignore host part when matching (ie. all hosts handled equally), then skip host part from cache key to reduce cache size as each different client host address shares same cache key.